### PR TITLE
add arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +500,52 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "compact_str"
@@ -1055,6 +1151,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,6 +1656,7 @@ dependencies = [
  "anyhow",
  "aws-config",
  "aws-sdk-ec2",
+ "clap",
  "configparser",
  "crossterm",
  "home",
@@ -1887,6 +1990,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ home = "0.5.11"
 thiserror = "2.0.11"
 serde = { version = "1.0.218", features = ["derive"] }
 serde_json = "1.0.139"
+clap = { version = "4.5.3", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ This is caused by MacOS blocking unsigned binary, you can create an exception by
 
 # Usage
 
+## Interactive Mode
+
 ```sh
 export AWS_PROFILE=my-profile
 aws sso login
@@ -45,6 +47,29 @@ sm_connect
 1. Select the __region__ that contains your instance.
 2. Select the __instance__ you want to connect to.
 4. __Connect__ and enjoy!
+
+## Command-line Arguments
+
+You can also connect directly to an instance by providing the region and instance ID as command-line arguments:
+
+```sh
+export AWS_PROFILE=my-profile
+aws sso login
+sm_connect --region us-east-1 --instance i-ad53d5e3831ea
+```
+
+Or using the short form:
+
+```sh
+sm_connect -r us-east-1 -i i-ad53d5e3831ea
+```
+
+### Available Options
+
+- `-r, --region <REGION>`: AWS region (e.g., us-east-1, us-west-2)
+- `-i, --instance <INSTANCE>`: AWS EC2 instance ID (e.g., i-ad53d5e3831ea)
+- `-h, --help`: Print help information
+- `-V, --version`: Print version information
 
 [aws-cli-install]: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
 [aws-sm-install]: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -36,6 +36,17 @@ impl From<(Instance, Region)> for InstanceInfo {
 }
 
 impl InstanceInfo {
+    pub fn new(region: Region, instance_id: String) -> Self {
+        InstanceInfo {
+            region,
+            name: String::new(),
+            instance_id,
+            public_ip: String::new(),
+            private_ip: String::new(),
+            last_access: None,
+        }
+    }
+
     fn get_tags_map(instance: &Instance) -> HashMap<String, String> {
         let Some(ref tags) = instance.tags else {
             return HashMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,35 @@ use history::{History, HistoryEntry};
 mod screens;
 use anyhow::Result;
 use signal_hook::{consts::signal::*, iterator::Signals};
+use clap::Parser;
+use aws_config::Region;
+
+/// AWS Systems Manager Session Manager connection tool
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// AWS region (e.g., us-east-1, us-west-2)
+    #[arg(short, long)]
+    region: Option<String>,
+
+    /// AWS EC2 instance ID (e.g., i-ad53d5e3831ea)
+    #[arg(short, long)]
+    instance: Option<String>,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    // If both region and instance are provided, connect directly
+    if let (Some(region_str), Some(instance_id)) = (args.region, args.instance) {
+        let region = Region::new(region_str);
+        let instance = InstanceInfo::new(region, instance_id);
+        connect(instance)?;
+        return Ok(());
+    }
+
+    // Otherwise, run the interactive UI
     let mut app = App::new()?;
     let selected = app.run().await;
     drop(app);


### PR DESCRIPTION
## Command-line Arguments

You can also connect directly to an instance by providing the region and instance ID as command-line arguments:

```sh
export AWS_PROFILE=my-profile
aws sso login
sm_connect --region us-east-1 --instance i-ad53d5e3831ea
```

Or using the short form:

```sh
sm_connect -r us-east-1 -i i-ad53d5e3831ea
```

### Available Options

- `-r, --region <REGION>`: AWS region (e.g., us-east-1, us-west-2)
- `-i, --instance <INSTANCE>`: AWS EC2 instance ID (e.g., i-ad53d5e3831ea)
- `-h, --help`: Print help information
- `-V, --version`: Print version information