### PR TITLE
Add ECS Exec mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.3"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
+checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -299,6 +299,30 @@ dependencies = [
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ecs"
+version = "1.125.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4446bf0d1b00acf735257983201c5d80de6540ac3ec3f0b63648c64de0ce28e2"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
  "fastrand",
  "http 0.2.12",
  "http 1.4.0",
@@ -381,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
+checksum = "b7083fb918b38474ac65ffbf8a69fc8792d36879f4ac5f1667b43aec61efe9a5"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -465,10 +489,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.5"
+version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
 ]
 
@@ -493,15 +519,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
  "fastrand",
@@ -518,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -546,10 +573,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.4.7"
+name = "aws-smithy-schema"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -582,13 +620,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.15"
+version = "1.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -3799,6 +3838,7 @@ dependencies = [
  "anyhow",
  "aws-config",
  "aws-sdk-ec2",
+ "aws-sdk-ecs",
  "clap",
  "configparser",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ serde_json = "1.0.149"
 clap = { version = "4.6.1", features = ["derive"] }
 russh = "0.60"
 russh-sftp = "2.1"
+aws-sdk-ecs = "1.125.0"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Session Manager Connect
 =======================
 
-Session Manager Connect is a TUI to simplify using AWS Systems Manager's Session Manager to connect to EC2 instances
+Session Manager Connect is a TUI to simplify using AWS Systems Manager's Session Manager to connect to EC2 instances. It also supports Exec'ing into ECS tasks
 
 ![Demo](docs/demo.gif)
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ sm_connect
 ```
 
 1. The `sm_connect` TUI will launch.
-1. Select the __region__ that contains your instance.
-2. Select the __instance__ you want to connect to.
-4. __Connect__ and enjoy!
+1. Select the __region__ that contains your instance or task.
+1. Choose a __mode__: EC2 (Session Manager) or ECS (Exec).
+1. For EC2: select the __instance__ and __connect__.
+1. For ECS: select a __task__, then a __container__ (skipped if the task has only one), and a shell opens via `aws ecs execute-command`.
 
 ## Command-line Arguments
 
@@ -121,6 +122,23 @@ You will be prompted for the SSH username. After connecting, a dual-pane file ma
 
 > **Prerequisites:** SSH must be running on the instance (port 22). `ssh-agent` must be running locally with the correct key: `eval "$(ssh-agent -s)" && ssh-add ~/.ssh/id_rsa`
 
+## ECS Exec Mode
+
+After selecting a region, choose **ECS (Exec)** to browse running ECS tasks across all
+clusters in the region. Pick a task, then a container, and `sm_connect` opens an
+interactive `/bin/sh` shell in that container via `aws ecs execute-command`. If a task
+has a single container, the container step is skipped.
+
+> **Prerequisites:**
+> - The [Session Manager plugin][aws-sm-install] must be installed (same as EC2 mode).
+> - The task's service/task must be launched with **ECS Exec enabled**
+>   (`enableExecuteCommand`).
+> - The task role must grant the SSM permissions ECS Exec requires
+>   (`ssmmessages:*`).
+>
+> See the [ECS Exec documentation][ecs-exec] for setup details.
+
 [aws-cli-install]: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
 [aws-sm-install]: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html
 [aws-sm-config]: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started.html
+[ecs-exec]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec-run.html

--- a/docs/superpowers/plans/2026-05-27-ecs-exec.md
+++ b/docs/superpowers/plans/2026-05-27-ecs-exec.md
@@ -578,11 +578,13 @@ mod tests {
     use crate::aws::EcsTaskInfo;
     use aws_config::Region;
 
+    // Task id is a fixed, neutral value so a filter on the service name can only
+    // match via the service field (not incidentally via the task id).
     fn sample(service: &str) -> EcsTaskInfo {
         EcsTaskInfo::new(
             Region::new("us-east-1"),
             "arn:aws:ecs:us-east-1:123:cluster/prod".to_string(),
-            format!("arn:aws:ecs:us-east-1:123:task/prod/{}", service),
+            "arn:aws:ecs:us-east-1:123:task/prod/0123456789ab".to_string(),
             "arn:aws:ecs:us-east-1:123:task-definition/def:1".to_string(),
             format!("service:{}", service),
             "RUNNING".to_string(),

--- a/docs/superpowers/plans/2026-05-27-ecs-exec.md
+++ b/docs/superpowers/plans/2026-05-27-ecs-exec.md
@@ -251,8 +251,21 @@ pub async fn fetch_ecs_tasks(region: Region) -> Result<Vec<EcsTaskInfo>> {
         .await;
     let client = aws_sdk_ecs::Client::new(&config);
 
-    let clusters = client.list_clusters().send().await?;
-    let cluster_arns = clusters.cluster_arns.unwrap_or_default();
+    // Enumerate clusters, following pagination (ListClusters returns <=100 per page).
+    let mut cluster_arns: Vec<String> = Vec::new();
+    let mut clusters_token: Option<String> = None;
+    loop {
+        let resp = client
+            .list_clusters()
+            .set_next_token(clusters_token)
+            .send()
+            .await?;
+        cluster_arns.extend(resp.cluster_arns.unwrap_or_default());
+        clusters_token = resp.next_token;
+        if clusters_token.is_none() {
+            break;
+        }
+    }
 
     let mut tasks: Vec<EcsTaskInfo> = Vec::new();
 
@@ -283,6 +296,8 @@ pub async fn fetch_ecs_tasks(region: Region) -> Result<Vec<EcsTaskInfo>> {
                 .set_tasks(Some(chunk.to_vec()))
                 .send()
                 .await?;
+            // `described.failures` is intentionally ignored: a task that stopped
+            // between list_tasks and describe_tasks simply won't appear in the list.
             for task in described.tasks.unwrap_or_default() {
                 let task_arn = task.task_arn.clone().unwrap_or_default();
                 let task_definition_arn = task.task_definition_arn.clone().unwrap_or_default();

--- a/docs/superpowers/plans/2026-05-27-ecs-exec.md
+++ b/docs/superpowers/plans/2026-05-27-ecs-exec.md
@@ -785,6 +785,9 @@ pub enum TaskTableMessage {
     Search,
 }
 
+// Short-lived outcome enum built and matched immediately, so the size spread
+// between the data and unit variants does not matter (mirrors the EC2 outcome enums).
+#[allow(clippy::large_enum_variant)]
 pub enum TaskTableOutputAction {
     Exit,
     ReturnTask(EcsTaskInfo),
@@ -1285,6 +1288,9 @@ pub struct TaskSelectScreen {
     search_active: bool,
 }
 
+// Short-lived outcome enum built and matched immediately, so the size spread
+// between the data and unit variants does not matter (mirrors the EC2 outcome enums).
+#[allow(clippy::large_enum_variant)]
 pub enum TaskSelectScreenOutcome {
     Exit,
     Exec(EcsTaskInfo),

--- a/docs/superpowers/plans/2026-05-27-ecs-exec.md
+++ b/docs/superpowers/plans/2026-05-27-ecs-exec.md
@@ -1,0 +1,1833 @@
+# ECS Exec Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an interactive ECS Exec path to `sm_connect` so users can open a shell in a running ECS task's container, alongside the existing EC2 / Session Manager flow.
+
+**Architecture:** Mirror the existing EC2 screen stack. After region selection, a new ModeSelect screen branches to either the existing EC2 flow or a new ECS flow (`LoadingTasks → TaskSelect → ContainerSelect`). All screens follow the established Elm-style pattern (`Screen` trait returning an `Outcome`; screens hold `Component`s with `update`/`view`/`handle_event`). Async fetches reuse the generic `Loader<T>` + tokio task + oneshot channel. The final `UserAction::EcsExec` shells out to `aws ecs execute-command` via the existing `run_aws_command` helper.
+
+**Tech Stack:** Rust (edition 2024), ratatui 0.30, crossterm 0.29, tokio, anyhow, `aws-sdk-ec2` (existing) + `aws-sdk-ecs` (new), `aws-config`.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-27-ecs-exec-design.md`
+
+**Conventions to follow (from the existing codebase):**
+- Components implement `crate::components::Component` (`type Message`, `type OutputAction`, `update`, `view`, `handle_event`).
+- Screens implement `crate::screens::Screen` (`type Outcome`, `fn run`).
+- Build/run with debug only — **never** `--release` (see `CLAUDE.md`; the AWS crates are slow to compile).
+- Compile check command used throughout: `cargo build`.
+
+---
+
+## File structure
+
+**New files:**
+- `src/components/simple_list.rs` — single-select string list (reused by mode-select and container-select).
+- `src/components/task_table.rs` — searchable ECS task table (modeled on `instance_table.rs`).
+- `src/screens/mode_select_screen.rs` — EC2 vs ECS branch.
+- `src/screens/loading_tasks_screen.rs` — async fetch of ECS tasks (mirror of `loading_instances_screen.rs`).
+- `src/screens/task_select_screen.rs` — task table + search overlay (mirror of `instance_select_screen.rs`).
+- `src/screens/container_select_screen.rs` — pick a container.
+
+**Modified files:**
+- `Cargo.toml` / `Cargo.lock` — add `aws-sdk-ecs`.
+- `src/aws.rs` — add `EcsTaskInfo`, parsing helpers, `fetch_ecs_tasks`.
+- `src/components.rs` — register `simple_list`, `task_table`.
+- `src/components/header_tabs.rs` — make tab set configurable; add `Tasks` / `Container` variants.
+- `src/screens.rs` — register the three new screen modules.
+- `src/screens/region_select_screen.rs` — pass EC2 tab set to `HeaderTabs::new`.
+- `src/screens/instance_select_screen.rs` — pass EC2 tab set to `HeaderTabs::new`.
+- `src/app.rs` — new `SelectedScreen` variants, `UserAction::EcsExec`, wiring.
+- `src/main.rs` — `ecs_exec` handler + match arm.
+- `README.md` — document ECS exec + prerequisites.
+
+---
+
+## Task 1: Add `aws-sdk-ecs` dependency and `EcsTaskInfo` model with parsing helpers
+
+**Files:**
+- Modify: `Cargo.toml`, `Cargo.lock`
+- Modify: `src/aws.rs`
+
+- [ ] **Step 1: Add the ECS SDK dependency**
+
+Run:
+```bash
+cargo add aws-sdk-ecs
+```
+Expected: `Cargo.toml` gains an `aws-sdk-ecs = "1.x"` line and `Cargo.lock` updates. (Letting cargo pick the version avoids guessing one incompatible with the existing `aws-config` / `aws-sdk-ec2` generation.)
+
+- [ ] **Step 2: Write failing tests for the parsing helpers and constructor**
+
+Add this to the **end** of `src/aws.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_name_from_arn_takes_last_segment() {
+        assert_eq!(
+            short_name_from_arn("arn:aws:ecs:us-east-1:123:cluster/my-cluster"),
+            "my-cluster"
+        );
+        assert_eq!(
+            short_name_from_arn("arn:aws:ecs:us-east-1:123:task/my-cluster/abc123"),
+            "abc123"
+        );
+        // No slash: returns the input unchanged.
+        assert_eq!(short_name_from_arn("plain"), "plain");
+    }
+
+    #[test]
+    fn service_from_group_strips_service_prefix() {
+        assert_eq!(service_from_group("service:web-api"), "web-api");
+        // Standalone tasks have a non-service group -> empty.
+        assert_eq!(service_from_group("family:batch-job"), "");
+        assert_eq!(service_from_group(""), "");
+    }
+
+    #[test]
+    fn ecs_task_info_new_parses_display_fields() {
+        let task = EcsTaskInfo::new(
+            Region::new("us-east-1"),
+            "arn:aws:ecs:us-east-1:123:cluster/prod".to_string(),
+            "arn:aws:ecs:us-east-1:123:task/prod/deadbeef".to_string(),
+            "arn:aws:ecs:us-east-1:123:task-definition/web:7".to_string(),
+            "service:web-api".to_string(),
+            "RUNNING".to_string(),
+            vec!["app".to_string(), "sidecar".to_string()],
+        );
+        assert_eq!(task.cluster_name(), "prod");
+        assert_eq!(task.get_task_id(), "deadbeef");
+        assert_eq!(task.get_task_definition(), "web:7");
+        assert_eq!(task.get_service(), "web-api");
+        assert_eq!(task.get_last_status(), "RUNNING");
+        assert_eq!(task.get_containers(), &["app".to_string(), "sidecar".to_string()]);
+        // The raw cluster / task ARNs are preserved for the CLI command.
+        assert_eq!(task.get_cluster(), "arn:aws:ecs:us-east-1:123:cluster/prod");
+        assert_eq!(task.get_task_arn(), "arn:aws:ecs:us-east-1:123:task/prod/deadbeef");
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo test aws::tests 2>&1 | tail -20`
+Expected: FAIL — compile errors, `short_name_from_arn` / `service_from_group` / `EcsTaskInfo` not found.
+
+- [ ] **Step 4: Add the model, helpers, and constructor**
+
+Add the helpers and struct to `src/aws.rs` (place after the existing `InstanceInfo` impl block, before `fetch_instances`). The file already imports `aws_config::{BehaviorVersion, Region}`, which is all this step needs:
+
+```rust
+/// Returns the final `/`-delimited segment of an ARN (cluster name, task id, or
+/// `family:revision`). Returns the input unchanged when there is no `/`.
+fn short_name_from_arn(arn: &str) -> String {
+    arn.rsplit('/').next().unwrap_or(arn).to_string()
+}
+
+/// ECS task `group` is `service:<name>` for service-managed tasks. Returns the
+/// service name, or an empty string for standalone tasks.
+fn service_from_group(group: &str) -> String {
+    group.strip_prefix("service:").unwrap_or("").to_string()
+}
+
+#[derive(Debug, Clone)]
+pub struct EcsTaskInfo {
+    region: Region,
+    cluster: String,       // raw cluster ARN, passed to `--cluster`
+    cluster_name: String,  // short name, for display + search
+    task_arn: String,      // raw task ARN, passed to `--task`
+    task_id: String,       // short id, for display + search
+    task_definition: String,
+    service: String,
+    last_status: String,
+    containers: Vec<String>,
+}
+
+impl EcsTaskInfo {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        region: Region,
+        cluster_arn: String,
+        task_arn: String,
+        task_definition_arn: String,
+        group: String,
+        last_status: String,
+        containers: Vec<String>,
+    ) -> Self {
+        EcsTaskInfo {
+            region,
+            cluster_name: short_name_from_arn(&cluster_arn),
+            cluster: cluster_arn,
+            task_id: short_name_from_arn(&task_arn),
+            task_arn,
+            task_definition: short_name_from_arn(&task_definition_arn),
+            service: service_from_group(&group),
+            last_status,
+            containers,
+        }
+    }
+
+    pub fn get_region(&self) -> Region {
+        self.region.clone()
+    }
+
+    pub fn get_cluster(&self) -> &str {
+        &self.cluster
+    }
+
+    pub fn cluster_name(&self) -> &str {
+        &self.cluster_name
+    }
+
+    pub fn get_task_arn(&self) -> &str {
+        &self.task_arn
+    }
+
+    pub fn get_task_id(&self) -> &str {
+        &self.task_id
+    }
+
+    pub fn get_task_definition(&self) -> &str {
+        &self.task_definition
+    }
+
+    pub fn get_service(&self) -> &str {
+        &self.service
+    }
+
+    pub fn get_last_status(&self) -> &str {
+        &self.last_status
+    }
+
+    pub fn get_containers(&self) -> &[String] {
+        &self.containers
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test aws::tests 2>&1 | tail -20`
+Expected: PASS — 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock src/aws.rs
+git commit -m "Add aws-sdk-ecs dep and EcsTaskInfo model with parsing helpers"
+```
+
+---
+
+## Task 2: Implement `fetch_ecs_tasks`
+
+**Files:**
+- Modify: `src/aws.rs`
+
+This fetch hits AWS, so it is verified by compilation here and by manual testing in Task 13 (not unit-tested).
+
+- [ ] **Step 1: Add the import and fetch function**
+
+Add this import near the top of `src/aws.rs` (next to the existing `use aws_sdk_ec2::...` line):
+
+```rust
+use aws_sdk_ecs::types::DesiredStatus;
+```
+
+Then append the fetch function to `src/aws.rs` (after `fetch_instances`):
+
+```rust
+/// Enumerates all RUNNING ECS tasks across every cluster in the region.
+///
+/// Steps: list clusters -> for each cluster list RUNNING task ARNs (paginated) ->
+/// describe those tasks in batches of <=100 to pull group/definition/status/containers.
+pub async fn fetch_ecs_tasks(region: Region) -> Result<Vec<EcsTaskInfo>> {
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .region(region.clone())
+        .load()
+        .await;
+    let client = aws_sdk_ecs::Client::new(&config);
+
+    let clusters = client.list_clusters().send().await?;
+    let cluster_arns = clusters.cluster_arns.unwrap_or_default();
+
+    let mut tasks: Vec<EcsTaskInfo> = Vec::new();
+
+    for cluster_arn in cluster_arns {
+        // Collect RUNNING task ARNs for this cluster, following pagination.
+        let mut task_arns: Vec<String> = Vec::new();
+        let mut next_token: Option<String> = None;
+        loop {
+            let resp = client
+                .list_tasks()
+                .cluster(&cluster_arn)
+                .desired_status(DesiredStatus::Running)
+                .set_next_token(next_token)
+                .send()
+                .await?;
+            task_arns.extend(resp.task_arns.unwrap_or_default());
+            next_token = resp.next_token;
+            if next_token.is_none() {
+                break;
+            }
+        }
+
+        // describe_tasks accepts at most 100 task ARNs per call.
+        for chunk in task_arns.chunks(100) {
+            let described = client
+                .describe_tasks()
+                .cluster(&cluster_arn)
+                .set_tasks(Some(chunk.to_vec()))
+                .send()
+                .await?;
+            for task in described.tasks.unwrap_or_default() {
+                let task_arn = task.task_arn.clone().unwrap_or_default();
+                let task_definition_arn = task.task_definition_arn.clone().unwrap_or_default();
+                let group = task.group.clone().unwrap_or_default();
+                let last_status = task.last_status.clone().unwrap_or_default();
+                let containers = task
+                    .containers
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(|c| c.name)
+                    .collect();
+                tasks.push(EcsTaskInfo::new(
+                    region.clone(),
+                    cluster_arn.clone(),
+                    task_arn,
+                    task_definition_arn,
+                    group,
+                    last_status,
+                    containers,
+                ));
+            }
+        }
+    }
+
+    Ok(tasks)
+}
+```
+
+- [ ] **Step 2: Verify it compiles (and the earlier unused-import warning is gone)**
+
+Run: `cargo build 2>&1 | tail -20`
+Expected: builds successfully, no `unused import: DesiredStatus` warning.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/aws.rs
+git commit -m "Add fetch_ecs_tasks: enumerate running ECS tasks across clusters"
+```
+
+---
+
+## Task 3: `SimpleList` component
+
+A minimal single-select string list, reused by mode-select and container-select.
+
+**Files:**
+- Create: `src/components/simple_list.rs`
+- Modify: `src/components.rs`
+
+- [ ] **Step 1: Register the module**
+
+Add to `src/components.rs` (with the other `pub mod` lines, keep alphabetical-ish grouping):
+
+```rust
+pub mod simple_list;
+```
+
+- [ ] **Step 2: Write failing navigation tests**
+
+Create `src/components/simple_list.rs` with ONLY the test module first (the rest is added in Step 4):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_wraps_around() {
+        let mut list = SimpleList::new(vec!["a".into(), "b".into()]);
+        assert_eq!(list.current(), Some("a".to_string()));
+        list.next();
+        assert_eq!(list.current(), Some("b".to_string()));
+        list.next(); // wraps to start
+        assert_eq!(list.current(), Some("a".to_string()));
+    }
+
+    #[test]
+    fn previous_wraps_around() {
+        let mut list = SimpleList::new(vec!["a".into(), "b".into()]);
+        list.previous(); // wraps to end
+        assert_eq!(list.current(), Some("b".to_string()));
+    }
+
+    #[test]
+    fn empty_list_has_no_current() {
+        let list = SimpleList::new(vec![]);
+        assert_eq!(list.current(), None);
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo test components::simple_list 2>&1 | tail -20`
+Expected: FAIL — `SimpleList` not found.
+
+- [ ] **Step 4: Implement the component**
+
+Add ABOVE the test module in `src/components/simple_list.rs`:
+
+```rust
+use crossterm::event::{Event, KeyCode};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    widgets::{Block, Borders, List, ListItem, ListState, Row, Table},
+};
+
+use super::{Component, get_help_styled};
+use anyhow::Result;
+
+#[derive(Debug, Clone)]
+pub struct SimpleList {
+    state: ListState,
+    items: Vec<String>,
+}
+
+impl SimpleList {
+    pub fn new(items: Vec<String>) -> SimpleList {
+        let mut state = ListState::default();
+        if !items.is_empty() {
+            state.select(Some(0));
+        }
+        SimpleList { state, items }
+    }
+
+    fn next(&mut self) {
+        if self.items.is_empty() {
+            return;
+        }
+        let i = match self.state.selected() {
+            Some(i) if i >= self.items.len() - 1 => 0,
+            Some(i) => i + 1,
+            None => 0,
+        };
+        self.state.select(Some(i));
+    }
+
+    fn previous(&mut self) {
+        if self.items.is_empty() {
+            return;
+        }
+        let i = match self.state.selected() {
+            Some(0) | None => self.items.len() - 1,
+            Some(i) => i - 1,
+        };
+        self.state.select(Some(i));
+    }
+
+    fn current(&self) -> Option<String> {
+        self.state.selected().map(|i| self.items[i].clone())
+    }
+
+    fn get_list(&self) -> List<'_> {
+        let items: Vec<ListItem> = self
+            .items
+            .iter()
+            .map(|i| ListItem::new(i.clone()))
+            .collect();
+        List::new(items)
+            .block(Block::default().borders(Borders::ALL))
+            .highlight_style(
+                Style::default()
+                    .bg(Color::LightGreen)
+                    .fg(Color::Black)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .highlight_symbol(">> ")
+    }
+
+    fn get_help(&self) -> Table<'_> {
+        let rows = vec![Row::new(vec![get_help_styled('q', "Exit")])];
+        Table::new(rows, vec![Constraint::Min(10)])
+    }
+}
+
+pub enum SimpleListMessage {
+    Exit,
+    Up,
+    Down,
+    Enter,
+}
+
+pub enum SimpleListOutputAction {
+    Exit,
+    Return(String),
+}
+
+impl Component for SimpleList {
+    type Message = SimpleListMessage;
+    type OutputAction = SimpleListOutputAction;
+
+    fn update(&mut self, msg: Option<SimpleListMessage>) -> Result<Option<Self::OutputAction>> {
+        match msg {
+            Some(SimpleListMessage::Exit) => Ok(Some(SimpleListOutputAction::Exit)),
+            Some(SimpleListMessage::Up) => {
+                self.previous();
+                Ok(None)
+            }
+            Some(SimpleListMessage::Down) => {
+                self.next();
+                Ok(None)
+            }
+            Some(SimpleListMessage::Enter) => match self.current() {
+                Some(item) => Ok(Some(SimpleListOutputAction::Return(item))),
+                None => Ok(None),
+            },
+            None => Ok(None),
+        }
+    }
+
+    fn view(&mut self, frame: &mut Frame, area: Rect) {
+        let vertical_layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(vec![Constraint::Fill(1), Constraint::Max(1)])
+            .split(area);
+        let list = self.get_list();
+        frame.render_stateful_widget(list, vertical_layout[0], &mut self.state.clone());
+        let help = self.get_help();
+        frame.render_widget(help, vertical_layout[1]);
+    }
+
+    fn handle_event(&self, event: Event) -> Option<Self::Message> {
+        match event {
+            Event::Key(key) => match key.code {
+                KeyCode::Char('q') => Some(SimpleListMessage::Exit),
+                KeyCode::Down => Some(SimpleListMessage::Down),
+                KeyCode::Up => Some(SimpleListMessage::Up),
+                KeyCode::Right | KeyCode::Enter => Some(SimpleListMessage::Enter),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test components::simple_list 2>&1 | tail -20`
+Expected: PASS — 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components.rs src/components/simple_list.rs
+git commit -m "Add SimpleList single-select component"
+```
+
+---
+
+## Task 4: `TaskTable` component
+
+Searchable ECS task table, modeled on `instance_table.rs`.
+
+**Files:**
+- Create: `src/components/task_table.rs`
+- Modify: `src/components.rs`
+
+- [ ] **Step 1: Register the module**
+
+Add to `src/components.rs`:
+
+```rust
+pub mod task_table;
+```
+
+- [ ] **Step 2: Write a failing filter test**
+
+Create `src/components/task_table.rs` with ONLY the test module first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::aws::EcsTaskInfo;
+    use aws_config::Region;
+
+    fn sample(service: &str) -> EcsTaskInfo {
+        EcsTaskInfo::new(
+            Region::new("us-east-1"),
+            "arn:aws:ecs:us-east-1:123:cluster/prod".to_string(),
+            format!("arn:aws:ecs:us-east-1:123:task/prod/{}", service),
+            "arn:aws:ecs:us-east-1:123:task-definition/def:1".to_string(),
+            format!("service:{}", service),
+            "RUNNING".to_string(),
+            vec!["app".to_string()],
+        )
+    }
+
+    #[test]
+    fn apply_filter_matches_service_substring() {
+        let mut table = TaskTable::new();
+        table.set_tasks(vec![sample("web-api"), sample("worker")]);
+        table.apply_filter("web".to_string());
+        assert_eq!(table.visible_len(), 1);
+        assert_eq!(table.current().unwrap().get_service(), "web-api");
+    }
+
+    #[test]
+    fn empty_filter_shows_all() {
+        let mut table = TaskTable::new();
+        table.set_tasks(vec![sample("web-api"), sample("worker")]);
+        table.apply_filter(String::new());
+        assert_eq!(table.visible_len(), 2);
+    }
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cargo test components::task_table 2>&1 | tail -20`
+Expected: FAIL — `TaskTable` not found.
+
+- [ ] **Step 4: Implement the component**
+
+Add ABOVE the test module in `src/components/task_table.rs`:
+
+```rust
+use crate::aws::EcsTaskInfo;
+use crossterm::event::{Event, KeyCode};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    widgets::{Block, Borders, Cell, Row, Table, TableState},
+};
+
+use super::{Component, get_help_styled};
+use anyhow::Result;
+
+#[derive(Debug, Clone)]
+pub struct TaskTable {
+    pub state: TableState,
+    items: Vec<EcsTaskInfo>,
+    visible_items: Vec<EcsTaskInfo>,
+    filter: String,
+}
+
+impl TaskTable {
+    pub fn new() -> TaskTable {
+        TaskTable {
+            state: TableState::default(),
+            items: vec![],
+            visible_items: vec![],
+            filter: String::default(),
+        }
+    }
+
+    pub fn set_tasks(&mut self, tasks: Vec<EcsTaskInfo>) {
+        self.items = tasks;
+        self.apply_filter(self.filter.clone());
+    }
+
+    /// Case-insensitive substring match across cluster, task id, definition,
+    /// service, and status.
+    pub fn apply_filter(&mut self, filter: String) {
+        self.filter = filter;
+        let needle = self.filter.to_lowercase();
+        self.visible_items = self
+            .items
+            .iter()
+            .filter(|t| {
+                let haystack = format!(
+                    "{} {} {} {} {}",
+                    t.cluster_name(),
+                    t.get_task_id(),
+                    t.get_task_definition(),
+                    t.get_service(),
+                    t.get_last_status(),
+                )
+                .to_lowercase();
+                haystack.contains(&needle)
+            })
+            .cloned()
+            .collect();
+        self.state.select(if self.visible_items.is_empty() {
+            None
+        } else {
+            Some(0)
+        });
+    }
+
+    #[cfg(test)]
+    pub fn visible_len(&self) -> usize {
+        self.visible_items.len()
+    }
+
+    pub fn next(&mut self) {
+        if self.visible_items.is_empty() {
+            return;
+        }
+        let i = match self.state.selected() {
+            Some(i) if i >= self.visible_items.len() - 1 => 0,
+            Some(i) => i + 1,
+            None => 0,
+        };
+        self.state.select(Some(i));
+    }
+
+    pub fn previous(&mut self) {
+        if self.visible_items.is_empty() {
+            return;
+        }
+        let i = match self.state.selected() {
+            Some(0) | None => self.visible_items.len() - 1,
+            Some(i) => i - 1,
+        };
+        self.state.select(Some(i));
+    }
+
+    pub fn current(&self) -> Option<EcsTaskInfo> {
+        self.state.selected().map(|i| self.visible_items[i].clone())
+    }
+
+    fn get_table(&self) -> Table<'_> {
+        let items: Vec<Row> = self
+            .visible_items
+            .iter()
+            .map(|t| {
+                Row::new(vec![
+                    Cell::from(t.cluster_name().to_string()),
+                    Cell::from(t.get_task_id().to_string()),
+                    Cell::from(t.get_task_definition().to_string()),
+                    Cell::from(t.get_service().to_string()),
+                    Cell::from(t.get_last_status().to_string()),
+                    Cell::from(t.get_containers().len().to_string()),
+                ])
+                .height(1)
+            })
+            .collect();
+        let widths = [
+            Constraint::Percentage(18),
+            Constraint::Percentage(22),
+            Constraint::Percentage(22),
+            Constraint::Percentage(20),
+            Constraint::Percentage(10),
+            Constraint::Percentage(8),
+        ];
+        Table::new(items, widths)
+            .block(Block::default().borders(Borders::ALL))
+            .row_highlight_style(
+                Style::default()
+                    .bg(Color::LightGreen)
+                    .fg(Color::Black)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .highlight_symbol(">> ")
+            .header(
+                Row::new(vec![
+                    "Cluster",
+                    "Task ID",
+                    "Task Definition",
+                    "Service",
+                    "Status",
+                    "Containers",
+                ])
+                .style(Style::default().add_modifier(Modifier::BOLD).underlined()),
+            )
+    }
+
+    fn get_help(&self) -> Table<'_> {
+        let rows = vec![Row::new(vec![
+            get_help_styled('q', "Exit"),
+            get_help_styled('/', "Search"),
+        ])];
+        Table::new(rows, vec![Constraint::Min(10), Constraint::Min(10)])
+    }
+}
+
+pub enum TaskTableMessage {
+    Exit,
+    Up,
+    Down,
+    Enter,
+    Search,
+}
+
+pub enum TaskTableOutputAction {
+    Exit,
+    ReturnTask(EcsTaskInfo),
+    Search,
+}
+
+impl Component for TaskTable {
+    type Message = TaskTableMessage;
+    type OutputAction = TaskTableOutputAction;
+
+    fn update(&mut self, msg: Option<TaskTableMessage>) -> Result<Option<Self::OutputAction>> {
+        let Some(msg) = msg else {
+            return Ok(None);
+        };
+        match msg {
+            TaskTableMessage::Exit => Ok(Some(TaskTableOutputAction::Exit)),
+            TaskTableMessage::Up => {
+                self.previous();
+                Ok(None)
+            }
+            TaskTableMessage::Down => {
+                self.next();
+                Ok(None)
+            }
+            TaskTableMessage::Enter => match self.current() {
+                Some(task) => Ok(Some(TaskTableOutputAction::ReturnTask(task))),
+                None => Ok(None),
+            },
+            TaskTableMessage::Search => Ok(Some(TaskTableOutputAction::Search)),
+        }
+    }
+
+    fn view(&mut self, frame: &mut Frame, area: Rect) {
+        let vertical_layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(vec![Constraint::Fill(1), Constraint::Max(1)])
+            .split(area);
+        let widget = self.get_table();
+        frame.render_stateful_widget(widget, vertical_layout[0], &mut self.state.clone());
+        let help = self.get_help();
+        frame.render_widget(help, vertical_layout[1]);
+    }
+
+    fn handle_event(&self, event: Event) -> Option<Self::Message> {
+        match event {
+            Event::Key(key) => match key.code {
+                KeyCode::Char('q') => Some(TaskTableMessage::Exit),
+                KeyCode::Down => Some(TaskTableMessage::Down),
+                KeyCode::Up => Some(TaskTableMessage::Up),
+                KeyCode::Right | KeyCode::Enter => Some(TaskTableMessage::Enter),
+                KeyCode::Char('/') => Some(TaskTableMessage::Search),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo test components::task_table 2>&1 | tail -20`
+Expected: PASS — 2 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components.rs src/components/task_table.rs
+git commit -m "Add searchable TaskTable component"
+```
+
+---
+
+## Task 5: Make `HeaderTabs` tab-set-aware
+
+The header is a flow/progress indicator. Make its tab set configurable so the ECS screens show `Region / Tasks / Container` while EC2 keeps `Region / Instances / Connection`. (ModeSelect keeps the EC2 set per the spec.)
+
+**Files:**
+- Modify: `src/components/header_tabs.rs`
+- Modify: `src/screens/region_select_screen.rs`
+- Modify: `src/screens/instance_select_screen.rs`
+
+- [ ] **Step 1: Replace `src/components/header_tabs.rs` contents**
+
+Replace the **entire file** with:
+
+```rust
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::Style,
+    text::Line,
+    widgets::{Block, Tabs},
+};
+
+use super::Component;
+
+pub struct HeaderTabs {
+    tabs: Vec<Tab>,
+    selected: Option<Tab>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tab {
+    Region,
+    Instances,
+    Connection,
+    Tasks,
+    Container,
+}
+
+impl Tab {
+    pub fn get_tab(&self) -> &'static str {
+        match self {
+            Tab::Region => "Region",
+            Tab::Instances => "Instances",
+            Tab::Connection => "Connection",
+            Tab::Tasks => "Tasks",
+            Tab::Container => "Container",
+        }
+    }
+
+    /// The EC2 / Session Manager flow steps.
+    pub fn ec2_flow() -> Vec<Tab> {
+        vec![Tab::Region, Tab::Instances, Tab::Connection]
+    }
+
+    /// The ECS Exec flow steps.
+    pub fn ecs_flow() -> Vec<Tab> {
+        vec![Tab::Region, Tab::Tasks, Tab::Container]
+    }
+}
+
+impl From<Tab> for Line<'static> {
+    fn from(val: Tab) -> Self {
+        Line::raw(val.get_tab())
+    }
+}
+
+impl HeaderTabs {
+    pub fn new(tabs: Vec<Tab>) -> Self {
+        Self {
+            tabs,
+            selected: None,
+        }
+    }
+
+    pub fn set_selected(&mut self, tab: Tab) {
+        self.selected = Some(tab);
+    }
+}
+
+pub enum HeaderTabMessage {}
+pub enum HeaderTabOutputAction {}
+
+impl Component for HeaderTabs {
+    type Message = HeaderTabMessage;
+    type OutputAction = HeaderTabOutputAction;
+    fn update(
+        &mut self,
+        _msg: Option<HeaderTabMessage>,
+    ) -> anyhow::Result<Option<Self::OutputAction>> {
+        Ok(None)
+    }
+
+    fn view(&mut self, frame: &mut Frame, area: Rect) {
+        let selected_index = self
+            .selected
+            .and_then(|sel| self.tabs.iter().position(|t| *t == sel));
+        let tabs = Tabs::new(self.tabs.clone())
+            .block(Block::bordered())
+            .style(Style::default().white())
+            .highlight_style(Style::default().yellow())
+            .select(selected_index);
+        frame.render_widget(tabs, area);
+    }
+
+    fn handle_event(&self, _event: crossterm::event::Event) -> Option<Self::Message> {
+        None
+    }
+}
+```
+
+- [ ] **Step 2: Update the region-select call site**
+
+In `src/screens/region_select_screen.rs`, find in `RegionSelectScreen::new`:
+
+```rust
+        let mut header_tabs_component = HeaderTabs::new();
+        header_tabs_component.set_selected(Tab::Region);
+```
+
+Replace with:
+
+```rust
+        let mut header_tabs_component = HeaderTabs::new(Tab::ec2_flow());
+        header_tabs_component.set_selected(Tab::Region);
+```
+
+- [ ] **Step 3: Update the instance-select call site**
+
+In `src/screens/instance_select_screen.rs`, find in `InstanceSelectScreen::new`:
+
+```rust
+        let mut header_tabs_component = HeaderTabs::new();
+        header_tabs_component.set_selected(Tab::Instances);
+```
+
+Replace with:
+
+```rust
+        let mut header_tabs_component = HeaderTabs::new(Tab::ec2_flow());
+        header_tabs_component.set_selected(Tab::Instances);
+```
+
+- [ ] **Step 4: Verify it compiles and existing tests pass**
+
+Run: `cargo build 2>&1 | tail -20 && cargo test 2>&1 | tail -10`
+Expected: builds; all existing tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/header_tabs.rs src/screens/region_select_screen.rs src/screens/instance_select_screen.rs
+git commit -m "Make HeaderTabs tab-set-aware; add Tasks/Container steps"
+```
+
+---
+
+## Task 6: `ModeSelectScreen`
+
+EC2 vs ECS branch. Uses `SimpleList` + EC2 header tabs.
+
+**Files:**
+- Create: `src/screens/mode_select_screen.rs`
+- Modify: `src/screens.rs`
+
+- [ ] **Step 1: Register the module**
+
+Add to `src/screens.rs` (with the other `pub mod` lines):
+
+```rust
+pub mod mode_select_screen;
+```
+
+- [ ] **Step 2: Create the screen**
+
+Create `src/screens/mode_select_screen.rs`:
+
+```rust
+use std::io::Stdout;
+
+use crossterm::event;
+use ratatui::{
+    Terminal,
+    layout::{Constraint, Direction, Layout},
+    prelude::CrosstermBackend,
+};
+
+use crate::components::{
+    Component,
+    header_tabs::{HeaderTabs, Tab},
+    simple_list::{SimpleList, SimpleListOutputAction},
+};
+
+use super::Screen;
+use anyhow::Result;
+
+const MODE_EC2: &str = "EC2 (Session Manager)";
+const MODE_ECS: &str = "ECS (Exec)";
+
+pub struct ModeSelectScreen {
+    header_tabs_component: HeaderTabs,
+    list: SimpleList,
+}
+
+pub enum ModeSelectScreenOutcome {
+    Exit,
+    Ec2,
+    Ecs,
+}
+
+impl ModeSelectScreen {
+    pub fn new() -> Self {
+        let header_tabs_component = HeaderTabs::new(Tab::ec2_flow());
+        let list = SimpleList::new(vec![MODE_EC2.to_string(), MODE_ECS.to_string()]);
+        Self {
+            header_tabs_component,
+            list,
+        }
+    }
+}
+
+impl Screen for ModeSelectScreen {
+    type Outcome = ModeSelectScreenOutcome;
+    fn run(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    ) -> Result<ModeSelectScreenOutcome> {
+        loop {
+            terminal.draw(|frame| {
+                let layout = Layout::default()
+                    .direction(Direction::Vertical)
+                    .margin(0)
+                    .constraints([Constraint::Max(3), Constraint::Fill(1)].as_ref())
+                    .split(frame.area());
+                self.header_tabs_component.view(frame, layout[0]);
+                self.list.view(frame, layout[1]);
+            })?;
+            let message = self.list.handle_event(event::read()?);
+            match self.list.update(message)? {
+                Some(SimpleListOutputAction::Exit) => return Ok(ModeSelectScreenOutcome::Exit),
+                Some(SimpleListOutputAction::Return(choice)) => {
+                    if choice == MODE_ECS {
+                        return Ok(ModeSelectScreenOutcome::Ecs);
+                    } else {
+                        return Ok(ModeSelectScreenOutcome::Ec2);
+                    }
+                }
+                None => {}
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cargo build 2>&1 | tail -20`
+Expected: builds (a `dead_code` warning for `ModeSelectScreen` is fine until Task 10 wires it in).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/screens.rs src/screens/mode_select_screen.rs
+git commit -m "Add ModeSelectScreen (EC2 vs ECS branch)"
+```
+
+---
+
+## Task 7: `LoadingTasksScreen`
+
+Async fetch of ECS tasks. Mirror of `loading_instances_screen.rs`.
+
+**Files:**
+- Create: `src/screens/loading_tasks_screen.rs`
+- Modify: `src/screens.rs`
+
+- [ ] **Step 1: Register the module**
+
+Add to `src/screens.rs`:
+
+```rust
+pub mod loading_tasks_screen;
+```
+
+- [ ] **Step 2: Create the screen**
+
+Create `src/screens/loading_tasks_screen.rs`:
+
+```rust
+use std::{io::Stdout, time::Duration};
+
+use anyhow::{Context, Result};
+use crossterm::event;
+use ratatui::{Terminal, prelude::CrosstermBackend};
+use tokio::sync::oneshot;
+
+use crate::{
+    aws::EcsTaskInfo,
+    components::{
+        Component,
+        loader::{Loader, LoaderOutputAction},
+    },
+};
+
+use super::Screen;
+
+type FetchResult = Result<Vec<EcsTaskInfo>>;
+
+pub struct LoadingTasksScreen {
+    loader: Loader<FetchResult>,
+}
+
+pub enum LoadingTasksScreenOutcome {
+    Cancelled,
+    TasksFetched(Vec<EcsTaskInfo>),
+}
+
+impl LoadingTasksScreen {
+    pub fn new(region: String) -> Self {
+        let (tx, rx) = oneshot::channel();
+        let message = format!("Loading ECS tasks for region {}", region);
+        tokio::spawn(async move {
+            let _ = tx.send(crate::aws::fetch_ecs_tasks(aws_config::Region::new(region)).await);
+        });
+        Self {
+            loader: Loader::new(message, rx),
+        }
+    }
+}
+
+impl Screen for LoadingTasksScreen {
+    type Outcome = LoadingTasksScreenOutcome;
+    fn run(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    ) -> Result<LoadingTasksScreenOutcome> {
+        loop {
+            terminal.draw(|frame| self.loader.view(frame, frame.area()))?;
+            let message = if event::poll(Duration::from_millis(50))? {
+                self.loader.handle_event(event::read()?)
+            } else {
+                None
+            };
+            let action = self
+                .loader
+                .update(message)
+                .context("Unexpected error while fetching ECS tasks")?;
+            match action {
+                Some(LoaderOutputAction::Exit) => return Ok(LoadingTasksScreenOutcome::Cancelled),
+                Some(LoaderOutputAction::Return(data)) => {
+                    return Ok(LoadingTasksScreenOutcome::TasksFetched(
+                        data.context("Failed to fetch ECS tasks. Check your AWS credentials.")?,
+                    ));
+                }
+                None => {}
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cargo build 2>&1 | tail -20`
+Expected: builds (dead_code warning until Task 10).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/screens.rs src/screens/loading_tasks_screen.rs
+git commit -m "Add LoadingTasksScreen (async ECS task fetch)"
+```
+
+---
+
+## Task 8: `TaskSelectScreen`
+
+Task table + search overlay. Mirror of `instance_select_screen.rs`.
+
+**Files:**
+- Create: `src/screens/task_select_screen.rs`
+- Modify: `src/screens.rs`
+
+- [ ] **Step 1: Register the module**
+
+Add to `src/screens.rs`:
+
+```rust
+pub mod task_select_screen;
+```
+
+- [ ] **Step 2: Create the screen**
+
+Create `src/screens/task_select_screen.rs`:
+
+```rust
+use std::io::Stdout;
+
+use crossterm::event;
+use ratatui::{
+    Terminal,
+    layout::{Constraint, Layout},
+    prelude::CrosstermBackend,
+    widgets::Clear,
+};
+
+use crate::{
+    aws::EcsTaskInfo,
+    components::{
+        Component,
+        header_tabs::{HeaderTabs, Tab},
+        task_table::{TaskTable, TaskTableOutputAction},
+        text_input::{TextInput, TextInputOutputAction},
+    },
+};
+
+use super::Screen;
+use anyhow::Result;
+
+pub struct TaskSelectScreen {
+    header_tabs_component: HeaderTabs,
+    task_table_component: TaskTable,
+    search_component: TextInput,
+    search_active: bool,
+}
+
+pub enum TaskSelectScreenOutcome {
+    Exit,
+    Exec(EcsTaskInfo),
+}
+
+impl TaskSelectScreen {
+    pub fn new() -> TaskSelectScreen {
+        let task_table_component = TaskTable::new();
+        let search_component = TextInput::default();
+        let mut header_tabs_component = HeaderTabs::new(Tab::ecs_flow());
+        header_tabs_component.set_selected(Tab::Tasks);
+        Self {
+            header_tabs_component,
+            task_table_component,
+            search_component,
+            search_active: false,
+        }
+    }
+
+    pub fn set_tasks(&mut self, tasks: Vec<EcsTaskInfo>) {
+        self.task_table_component.set_tasks(tasks);
+    }
+
+    fn draw(&mut self, terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
+        terminal.draw(|frame| {
+            let layout = Layout::default()
+                .direction(ratatui::layout::Direction::Vertical)
+                .margin(0)
+                .constraints([Constraint::Max(3), Constraint::Fill(1)].as_ref())
+                .split(frame.area());
+            self.header_tabs_component.view(frame, layout[0]);
+            self.task_table_component.view(frame, layout[1]);
+            if self.search_active {
+                let search_layout = Layout::default()
+                    .direction(ratatui::layout::Direction::Vertical)
+                    .constraints(vec![Constraint::Fill(1), Constraint::Max(3)])
+                    .split(layout[1]);
+                frame.render_widget(Clear, search_layout[1]);
+                self.search_component.view(frame, search_layout[1]);
+            }
+        })?;
+        Ok(())
+    }
+}
+
+impl Screen for TaskSelectScreen {
+    type Outcome = TaskSelectScreenOutcome;
+    fn run(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    ) -> Result<TaskSelectScreenOutcome> {
+        loop {
+            self.draw(terminal)?;
+            let event = event::read()?;
+            if !self.search_active {
+                let message = self.task_table_component.handle_event(event);
+                let action = self.task_table_component.update(message)?;
+                match action {
+                    Some(TaskTableOutputAction::Exit) => return Ok(TaskSelectScreenOutcome::Exit),
+                    Some(TaskTableOutputAction::ReturnTask(task)) => {
+                        return Ok(TaskSelectScreenOutcome::Exec(task));
+                    }
+                    Some(TaskTableOutputAction::Search) => {
+                        self.search_active = true;
+                    }
+                    None => {}
+                }
+            } else {
+                let message = self.search_component.handle_event(event);
+                let action = self.search_component.update(message)?;
+                match action {
+                    Some(TextInputOutputAction::Exit) => {
+                        self.search_active = false;
+                    }
+                    Some(TextInputOutputAction::Return(search)) => {
+                        self.task_table_component.apply_filter(search);
+                        self.search_active = false;
+                    }
+                    Some(TextInputOutputAction::PartialReturn(search)) => {
+                        self.task_table_component.apply_filter(search);
+                    }
+                    Some(TextInputOutputAction::ReturnWithKeyUp) => {
+                        self.task_table_component.previous();
+                        self.search_active = false;
+                    }
+                    Some(TextInputOutputAction::ReturnWithKeyDown) => {
+                        self.task_table_component.next();
+                        self.search_active = false;
+                    }
+                    None => {}
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cargo build 2>&1 | tail -20`
+Expected: builds (dead_code warning until Task 10).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/screens.rs src/screens/task_select_screen.rs
+git commit -m "Add TaskSelectScreen (searchable task table)"
+```
+
+---
+
+## Task 9: `ContainerSelectScreen`
+
+Pick a container from the selected task. Uses `SimpleList` + ECS header tabs.
+
+**Files:**
+- Create: `src/screens/container_select_screen.rs`
+- Modify: `src/screens.rs`
+
+- [ ] **Step 1: Register the module**
+
+Add to `src/screens.rs`:
+
+```rust
+pub mod container_select_screen;
+```
+
+- [ ] **Step 2: Create the screen**
+
+Create `src/screens/container_select_screen.rs`:
+
+```rust
+use std::io::Stdout;
+
+use crossterm::event;
+use ratatui::{
+    Terminal,
+    layout::{Constraint, Direction, Layout},
+    prelude::CrosstermBackend,
+};
+
+use crate::components::{
+    Component,
+    header_tabs::{HeaderTabs, Tab},
+    simple_list::{SimpleList, SimpleListOutputAction},
+};
+
+use super::Screen;
+use anyhow::Result;
+
+pub struct ContainerSelectScreen {
+    header_tabs_component: HeaderTabs,
+    list: SimpleList,
+}
+
+pub enum ContainerSelectScreenOutcome {
+    Exit,
+    Return(String),
+}
+
+impl ContainerSelectScreen {
+    pub fn new(containers: Vec<String>) -> Self {
+        let mut header_tabs_component = HeaderTabs::new(Tab::ecs_flow());
+        header_tabs_component.set_selected(Tab::Container);
+        let list = SimpleList::new(containers);
+        Self {
+            header_tabs_component,
+            list,
+        }
+    }
+}
+
+impl Screen for ContainerSelectScreen {
+    type Outcome = ContainerSelectScreenOutcome;
+    fn run(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    ) -> Result<ContainerSelectScreenOutcome> {
+        loop {
+            terminal.draw(|frame| {
+                let layout = Layout::default()
+                    .direction(Direction::Vertical)
+                    .margin(0)
+                    .constraints([Constraint::Max(3), Constraint::Fill(1)].as_ref())
+                    .split(frame.area());
+                self.header_tabs_component.view(frame, layout[0]);
+                self.list.view(frame, layout[1]);
+            })?;
+            let message = self.list.handle_event(event::read()?);
+            match self.list.update(message)? {
+                Some(SimpleListOutputAction::Exit) => {
+                    return Ok(ContainerSelectScreenOutcome::Exit);
+                }
+                Some(SimpleListOutputAction::Return(container)) => {
+                    return Ok(ContainerSelectScreenOutcome::Return(container));
+                }
+                None => {}
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cargo build 2>&1 | tail -20`
+Expected: builds (dead_code warning until Task 10).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/screens.rs src/screens/container_select_screen.rs
+git commit -m "Add ContainerSelectScreen"
+```
+
+---
+
+## Task 10: Wire the ECS flow into `app.rs`
+
+**Files:**
+- Modify: `src/app.rs`
+
+- [ ] **Step 1: Add imports**
+
+In `src/app.rs`, add to the `use crate::screens::...` import block (after the existing screen imports):
+
+```rust
+use crate::aws::EcsTaskInfo;
+use crate::screens::container_select_screen::{ContainerSelectScreen, ContainerSelectScreenOutcome};
+use crate::screens::loading_tasks_screen::{LoadingTasksScreen, LoadingTasksScreenOutcome};
+use crate::screens::mode_select_screen::{ModeSelectScreen, ModeSelectScreenOutcome};
+use crate::screens::task_select_screen::{TaskSelectScreen, TaskSelectScreenOutcome};
+```
+
+- [ ] **Step 2: Extend `UserAction`**
+
+Replace the `UserAction` enum with:
+
+```rust
+#[derive(Debug, Clone)]
+pub enum UserAction {
+    Connect(InstanceInfo),
+    Tunnel(InstanceInfo),
+    FileManager(InstanceInfo),
+    EcsExec { task: EcsTaskInfo, container: String },
+}
+```
+
+- [ ] **Step 3: Extend `SelectedScreen`**
+
+Replace the `SelectedScreen` enum with:
+
+```rust
+#[derive(Debug, Clone)]
+pub enum SelectedScreen {
+    RegionSelect,
+    ModeSelect(String),
+    LoadingInstances(String),
+    InstanceSelect,
+    LoadingTasks(String),
+    TaskSelect,
+    ContainerSelect,
+    Config,
+}
+```
+
+- [ ] **Step 4: Add screen state fields**
+
+In `struct App`, add these two fields after `instance_selection_screen`:
+
+```rust
+    task_select_screen: TaskSelectScreen,
+    selected_task: Option<EcsTaskInfo>,
+```
+
+In `App::new`, after `let instance_selection_screen = InstanceSelectScreen::new();` add:
+
+```rust
+        let task_select_screen = TaskSelectScreen::new();
+```
+
+And in the returned `Ok(App { ... })` literal, add after `instance_selection_screen,`:
+
+```rust
+            task_select_screen,
+            selected_task: None,
+```
+
+- [ ] **Step 5: Route region selection to ModeSelect**
+
+In the `SelectedScreen::RegionSelect` arm, change the `RegionSelected` branch from:
+
+```rust
+                        region_select_screen::RegionSelectScreenOutcome::RegionSelected(region) => {
+                            self.selected_screen = SelectedScreen::LoadingInstances(region);
+                        }
+```
+
+to:
+
+```rust
+                        region_select_screen::RegionSelectScreenOutcome::RegionSelected(region) => {
+                            self.selected_screen = SelectedScreen::ModeSelect(region);
+                        }
+```
+
+- [ ] **Step 6: Make LoadingInstances cancel return to ModeSelect**
+
+In the `SelectedScreen::LoadingInstances(region)` arm, change the `Cancelled` branch from:
+
+```rust
+                        loading_instances_screen::LoadingInstancesScreenOutcome::Cancelled => {
+                            self.selected_screen = SelectedScreen::RegionSelect;
+                        }
+```
+
+to:
+
+```rust
+                        loading_instances_screen::LoadingInstancesScreenOutcome::Cancelled => {
+                            self.selected_screen = SelectedScreen::ModeSelect(region);
+                        }
+```
+
+- [ ] **Step 7: Add the new match arms**
+
+Insert these arms into the `match self.selected_screen.clone()` block (e.g. immediately before the `SelectedScreen::Config => ...` arm):
+
+```rust
+                SelectedScreen::ModeSelect(region) => {
+                    match ModeSelectScreen::new().run(&mut self.terminal)? {
+                        ModeSelectScreenOutcome::Exit => {
+                            self.selected_screen = SelectedScreen::RegionSelect;
+                        }
+                        ModeSelectScreenOutcome::Ec2 => {
+                            self.selected_screen = SelectedScreen::LoadingInstances(region);
+                        }
+                        ModeSelectScreenOutcome::Ecs => {
+                            self.selected_screen = SelectedScreen::LoadingTasks(region);
+                        }
+                    }
+                }
+                SelectedScreen::LoadingTasks(region) => {
+                    match LoadingTasksScreen::new(region.clone()).run(&mut self.terminal)? {
+                        LoadingTasksScreenOutcome::Cancelled => {
+                            self.selected_screen = SelectedScreen::ModeSelect(region);
+                        }
+                        LoadingTasksScreenOutcome::TasksFetched(tasks) => {
+                            self.task_select_screen.set_tasks(tasks);
+                            self.selected_screen = SelectedScreen::TaskSelect;
+                        }
+                    }
+                }
+                SelectedScreen::TaskSelect => {
+                    match self.task_select_screen.run(&mut self.terminal)? {
+                        TaskSelectScreenOutcome::Exit => {
+                            self.selected_screen = SelectedScreen::RegionSelect;
+                        }
+                        TaskSelectScreenOutcome::Exec(task) => {
+                            if task.get_containers().len() == 1 {
+                                let container = task.get_containers()[0].clone();
+                                should_exit = true;
+                                return_value = Some(UserAction::EcsExec { task, container });
+                            } else {
+                                self.selected_task = Some(task);
+                                self.selected_screen = SelectedScreen::ContainerSelect;
+                            }
+                        }
+                    }
+                }
+                SelectedScreen::ContainerSelect => {
+                    let task = self
+                        .selected_task
+                        .clone()
+                        .expect("ContainerSelect requires a selected task");
+                    let containers = task.get_containers().to_vec();
+                    match ContainerSelectScreen::new(containers).run(&mut self.terminal)? {
+                        ContainerSelectScreenOutcome::Exit => {
+                            self.selected_screen = SelectedScreen::TaskSelect;
+                        }
+                        ContainerSelectScreenOutcome::Return(container) => {
+                            should_exit = true;
+                            return_value = Some(UserAction::EcsExec { task, container });
+                        }
+                    }
+                }
+```
+
+- [ ] **Step 8: Verify it compiles**
+
+Run: `cargo build 2>&1 | tail -30`
+Expected: builds. `main.rs` will warn about a non-exhaustive `match` on `UserAction` (missing `EcsExec`) — that is fixed in Task 11. If the build *errors* on that match, that is also expected and resolved next.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/app.rs
+git commit -m "Wire ECS flow (mode/tasks/container) into app state machine"
+```
+
+---
+
+## Task 11: Handle `EcsExec` in `main.rs`
+
+**Files:**
+- Modify: `src/main.rs`
+
+- [ ] **Step 1: Add the `ecs_exec` function**
+
+In `src/main.rs`, add after the `connect` function:
+
+```rust
+fn ecs_exec(task: aws::EcsTaskInfo, container: String) -> Result<()> {
+    run_aws_command(&[
+        "--region",
+        task.get_region().as_ref(),
+        "ecs",
+        "execute-command",
+        "--cluster",
+        task.get_cluster(),
+        "--task",
+        task.get_task_arn(),
+        "--container",
+        &container,
+        "--interactive",
+        "--command",
+        "/bin/sh",
+    ])
+}
+```
+
+- [ ] **Step 2: Add the match arm**
+
+In `main`, add to the `match selected { ... }` block, after the `FileManager` arm:
+
+```rust
+        Ok(Some(UserAction::EcsExec { task, container })) => ecs_exec(task, container)?,
+```
+
+- [ ] **Step 3: Verify it compiles cleanly**
+
+Run: `cargo build 2>&1 | tail -20`
+Expected: builds with no `UserAction` exhaustiveness warning/error.
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `cargo test 2>&1 | tail -15`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "Run aws ecs execute-command for EcsExec action"
+```
+
+---
+
+## Task 12: Update README
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add ECS exec to the intro and interactive steps**
+
+In `README.md`, in the "## Interactive Mode" numbered list, after the region step add a mode step. Change:
+
+```
+1. The `sm_connect` TUI will launch.
+1. Select the __region__ that contains your instance.
+2. Select the __instance__ you want to connect to.
+4. __Connect__ and enjoy!
+```
+
+to:
+
+```
+1. The `sm_connect` TUI will launch.
+1. Select the __region__ that contains your instance or task.
+1. Choose a __mode__: EC2 (Session Manager) or ECS (Exec).
+1. For EC2: select the __instance__ and __connect__.
+1. For ECS: select a __task__, then a __container__ (skipped if the task has only one), and a shell opens via `aws ecs execute-command`.
+```
+
+- [ ] **Step 2: Add an ECS Exec prerequisites section**
+
+After the "## File Manager Mode" section (before the link-reference footer lines beginning with `[aws-cli-install]:`), add:
+
+```markdown
+## ECS Exec Mode
+
+After selecting a region, choose **ECS (Exec)** to browse running ECS tasks across all
+clusters in the region. Pick a task, then a container, and `sm_connect` opens an
+interactive `/bin/sh` shell in that container via `aws ecs execute-command`. If a task
+has a single container, the container step is skipped.
+
+> **Prerequisites:**
+> - The [Session Manager plugin][aws-sm-install] must be installed (same as EC2 mode).
+> - The task's service/task must be launched with **ECS Exec enabled**
+>   (`enableExecuteCommand`).
+> - The task role must grant the SSM permissions ECS Exec requires
+>   (`ssmmessages:*`).
+>
+> See the [ECS Exec documentation][ecs-exec] for setup details.
+```
+
+- [ ] **Step 3: Add the link reference**
+
+At the bottom of `README.md`, with the other `[...]:` link-reference lines, add:
+
+```
+[ecs-exec]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec-run.html
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "Document ECS Exec mode in README"
+```
+
+---
+
+## Task 13: Final build, lint, and manual verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Clean build + full tests**
+
+Run: `cargo build 2>&1 | tail -20 && cargo test 2>&1 | tail -15`
+Expected: builds with no errors; all tests pass.
+
+- [ ] **Step 2: Clippy (best-effort)**
+
+Run: `cargo clippy 2>&1 | tail -30`
+Expected: no new errors. Warnings in pre-existing code are acceptable; address warnings in the new files if trivial.
+
+- [ ] **Step 3: Manual verification against a real account**
+
+This requires AWS credentials and at least one ECS cluster with an exec-enabled running task.
+
+```bash
+export AWS_PROFILE=<a-profile-with-ecs>
+aws sso login
+cargo run
+```
+
+Verify, in order:
+1. Region select → pick a region.
+2. Mode select appears with "EC2 (Session Manager)" and "ECS (Exec)"; the header shows the EC2 flow tabs.
+3. Choosing **ECS (Exec)** shows a loading spinner, then a task table with columns Cluster / Task ID / Task Definition / Service / Status / Containers; the header shows `Region / Tasks / Container`.
+4. `/` opens search; typing filters the tasks; Esc/Enter closes search.
+5. Selecting a task with **multiple** containers shows the container list; selecting one drops into a `/bin/sh` shell in that container.
+6. Selecting a task with **exactly one** container skips the container screen and drops straight into the shell.
+7. `q` from the task table exits back to region select; Esc on the loader cancels back to mode select.
+8. Choosing **EC2 (Session Manager)** still reaches the instance table and connects as before (no regression).
+
+- [ ] **Step 4: Confirm the branch is ready**
+
+Run: `git status && git log --oneline master..HEAD`
+Expected: clean working tree; commits for Tasks 1–12 present on the `ecs` branch.
+
+---
+
+## Notes for the implementer
+
+- **Never** build with `--release` (per `CLAUDE.md`).
+- The new screens are I/O loops and are not unit-tested; their logic-bearing components (`SimpleList`, `TaskTable`) and the `aws.rs` parsing helpers are. This matches the existing codebase, where screens are not unit-tested.
+- `--cluster` and `--task` are passed as full ARNs; the AWS CLI accepts ARNs for both. The short names are display/search only.
+- Out of scope (deferred per the spec): configurable exec command, direct ECS CLI args, ECS history/last-access, ECS tunnel/file-manager.

--- a/docs/superpowers/plans/2026-05-27-ecs-exec.md
+++ b/docs/superpowers/plans/2026-05-27-ecs-exec.md
@@ -1317,10 +1317,12 @@ impl TaskSelectScreen {
                     .direction(ratatui::layout::Direction::Vertical)
                     .constraints(vec![Constraint::Fill(1), Constraint::Max(3)])
                     .split(layout[1]);
-                frame.render_widget(Clear, search_layout[1]);
+                frame.render_widget(Clear, search_layout[1]); //this clears out the background
+                //TODO: Since we are drawing on top, maybe give it some distinct style?
                 self.search_component.view(frame, search_layout[1]);
             }
         })?;
+
         Ok(())
     }
 }
@@ -1352,6 +1354,8 @@ impl Screen for TaskSelectScreen {
                 let action = self.search_component.update(message)?;
                 match action {
                     Some(TextInputOutputAction::Exit) => {
+                        // Search text is intentionally kept so reopening (`/`) resumes
+                        // the previous query; matches instance_select_screen behavior.
                         self.search_active = false;
                     }
                     Some(TextInputOutputAction::Return(search)) => {

--- a/docs/superpowers/plans/2026-05-27-ecs-exec.md
+++ b/docs/superpowers/plans/2026-05-27-ecs-exec.md
@@ -457,7 +457,7 @@ impl SimpleList {
         let items: Vec<ListItem> = self
             .items
             .iter()
-            .map(|i| ListItem::new(i.clone()))
+            .map(|i| ListItem::new(i.as_str()))
             .collect();
         List::new(items)
             .block(Block::default().borders(Borders::ALL))

--- a/docs/superpowers/plans/2026-05-27-ecs-exec.md
+++ b/docs/superpowers/plans/2026-05-27-ecs-exec.md
@@ -98,7 +98,7 @@ mod tests {
             "RUNNING".to_string(),
             vec!["app".to_string(), "sidecar".to_string()],
         );
-        assert_eq!(task.cluster_name(), "prod");
+        assert_eq!(task.get_cluster_name(), "prod");
         assert_eq!(task.get_task_id(), "deadbeef");
         assert_eq!(task.get_task_definition(), "web:7");
         assert_eq!(task.get_service(), "web-api");
@@ -178,7 +178,7 @@ impl EcsTaskInfo {
         &self.cluster
     }
 
-    pub fn cluster_name(&self) -> &str {
+    pub fn get_cluster_name(&self) -> &str {
         &self.cluster_name
     }
 
@@ -650,7 +650,7 @@ impl TaskTable {
             .filter(|t| {
                 let haystack = format!(
                     "{} {} {} {} {}",
-                    t.cluster_name(),
+                    t.get_cluster_name(),
                     t.get_task_id(),
                     t.get_task_definition(),
                     t.get_service(),
@@ -706,7 +706,7 @@ impl TaskTable {
             .iter()
             .map(|t| {
                 Row::new(vec![
-                    Cell::from(t.cluster_name().to_string()),
+                    Cell::from(t.get_cluster_name().to_string()),
                     Cell::from(t.get_task_id().to_string()),
                     Cell::from(t.get_task_definition().to_string()),
                     Cell::from(t.get_service().to_string()),

--- a/docs/superpowers/plans/2026-05-27-ecs-exec.md
+++ b/docs/superpowers/plans/2026-05-27-ecs-exec.md
@@ -251,41 +251,27 @@ pub async fn fetch_ecs_tasks(region: Region) -> Result<Vec<EcsTaskInfo>> {
         .await;
     let client = aws_sdk_ecs::Client::new(&config);
 
-    // Enumerate clusters, following pagination (ListClusters returns <=100 per page).
+    // Enumerate clusters across all pages via the SDK paginator.
     let mut cluster_arns: Vec<String> = Vec::new();
-    let mut clusters_token: Option<String> = None;
-    loop {
-        let resp = client
-            .list_clusters()
-            .set_next_token(clusters_token)
-            .send()
-            .await?;
-        cluster_arns.extend(resp.cluster_arns.unwrap_or_default());
-        clusters_token = resp.next_token;
-        if clusters_token.is_none() {
-            break;
-        }
+    let mut cluster_pages = client.list_clusters().into_paginator().items().send();
+    while let Some(cluster_arn) = cluster_pages.next().await {
+        cluster_arns.push(cluster_arn?);
     }
 
     let mut tasks: Vec<EcsTaskInfo> = Vec::new();
 
     for cluster_arn in cluster_arns {
-        // Collect RUNNING task ARNs for this cluster, following pagination.
+        // Collect RUNNING task ARNs for this cluster across all pages.
         let mut task_arns: Vec<String> = Vec::new();
-        let mut next_token: Option<String> = None;
-        loop {
-            let resp = client
-                .list_tasks()
-                .cluster(&cluster_arn)
-                .desired_status(DesiredStatus::Running)
-                .set_next_token(next_token)
-                .send()
-                .await?;
-            task_arns.extend(resp.task_arns.unwrap_or_default());
-            next_token = resp.next_token;
-            if next_token.is_none() {
-                break;
-            }
+        let mut task_pages = client
+            .list_tasks()
+            .cluster(&cluster_arn)
+            .desired_status(DesiredStatus::Running)
+            .into_paginator()
+            .items()
+            .send();
+        while let Some(task_arn) = task_pages.next().await {
+            task_arns.push(task_arn?);
         }
 
         // describe_tasks accepts at most 100 task ARNs per call.

--- a/docs/superpowers/plans/2026-05-27-ecs-exec.md
+++ b/docs/superpowers/plans/2026-05-27-ecs-exec.md
@@ -1064,6 +1064,8 @@ pub enum ModeSelectScreenOutcome {
 
 impl ModeSelectScreen {
     pub fn new() -> Self {
+        // The mode picker sits before the flow branches, so no flow step is
+        // highlighted yet — intentionally no `set_selected` call here.
         let header_tabs_component = HeaderTabs::new(Tab::ec2_flow());
         let list = SimpleList::new(vec![MODE_EC2.to_string(), MODE_ECS.to_string()]);
         Self {

--- a/docs/superpowers/plans/2026-05-27-ecs-exec.md
+++ b/docs/superpowers/plans/2026-05-27-ecs-exec.md
@@ -1717,6 +1717,7 @@ fn ecs_exec(task: aws::EcsTaskInfo, container: String) -> Result<()> {
         &container,
         "--interactive",
         "--command",
+        // v1: shell is hardcoded; making this configurable is a deliberate future step.
         "/bin/sh",
     ])
 }

--- a/docs/superpowers/plans/2026-05-27-ecs-exec.md
+++ b/docs/superpowers/plans/2026-05-27-ecs-exec.md
@@ -303,12 +303,17 @@ pub async fn fetch_ecs_tasks(region: Region) -> Result<Vec<EcsTaskInfo>> {
                 let task_definition_arn = task.task_definition_arn.clone().unwrap_or_default();
                 let group = task.group.clone().unwrap_or_default();
                 let last_status = task.last_status.clone().unwrap_or_default();
-                let containers = task
+                let containers: Vec<String> = task
                     .containers
                     .unwrap_or_default()
                     .into_iter()
                     .filter_map(|c| c.name)
                     .collect();
+                // A task with no named containers can't be exec'd into; skip it
+                // so it never shows up as an unusable row / empty container picker.
+                if containers.is_empty() {
+                    continue;
+                }
                 tasks.push(EcsTaskInfo::new(
                     region.clone(),
                     cluster_arn.clone(),
@@ -1640,6 +1645,8 @@ Insert these arms into the `match self.selected_screen.clone()` block (e.g. imme
                 SelectedScreen::TaskSelect => {
                     match self.task_select_screen.run(&mut self.terminal)? {
                         TaskSelectScreenOutcome::Exit => {
+                            // Exiting the list starts over at region select, matching the
+                            // EC2 path (InstanceSelect Exit also returns to RegionSelect).
                             self.selected_screen = SelectedScreen::RegionSelect;
                         }
                         TaskSelectScreenOutcome::Exec(task) => {

--- a/docs/superpowers/plans/2026-05-27-mode-toggle.md
+++ b/docs/superpowers/plans/2026-05-27-mode-toggle.md
@@ -1,0 +1,713 @@
+# Configurable EC2 / ECS Mode Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users disable the EC2 or ECS mode they don't use via persistent config; when only one mode is enabled, the interactive flow skips Mode-Select and goes straight into that mode after region selection.
+
+**Architecture:** Add two boolean flags to the existing `Config` (persisted JSON at `~/.sm_connect.json`). The "at least one mode enabled" invariant is enforced in `Config::persist()` (the single write gate); toggles flip-then-revert-on-error so no invariant logic lives in the UI. A hand-edited both-off config is self-healed on load. The `ConfigScreen`/`ConfigList` gain two live-state toggle entries. `app.rs` routing reads the flags in one place (the `RegionSelected` transition) to skip Mode-Select for single-mode setups; all loading-screen cancels simplify to returning to Region select.
+
+**Tech Stack:** Rust (edition 2024), serde/serde_json (config), ratatui 0.30 (TUI). Binary crate — run tests with `cargo test <filter>` (NOT `--lib`).
+
+**Reference spec:** `docs/superpowers/specs/2026-05-27-mode-toggle-design.md`
+
+**Project rule (CLAUDE.md):** NEVER build with `--release` — the AWS crates are slow to compile. Use plain `cargo build` / `cargo test`.
+
+---
+
+## File structure
+
+**Modified files:**
+- `src/app/config.rs` — two `bool` flags, `persist()` write-gate, accessors, toggles, load self-heal, unit tests.
+- `src/components/config_list.rs` — two new `ConfigOption` variants with live-state labels; `ConfigList` gains the config handle.
+- `src/screens/config_screen.rs` — pass config to `ConfigList`; handle the two toggle actions.
+- `src/app.rs` — `config` field on `App`; inline routing match in `RegionSelected`; loading-screen cancels → `RegionSelect`.
+
+No new files.
+
+---
+
+## Task 1: Config flags, write-gate, toggles, and self-heal
+
+**Files:**
+- Modify: `src/app/config.rs`
+
+This is the data layer and is fully unit-testable. The tests are written to do **no filesystem IO**: they construct `Config::default()` (no IO) and set private fields directly (the test module is in the same file, so private fields are accessible), and the refusal test relies on `persist()` validating *before* it touches the filesystem.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this to the END of `src/app/config.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_valid_rejects_both_disabled() {
+        let mut c = Config::default();
+        assert!(c.ensure_valid().is_ok()); // both enabled by default
+        c.ec2_enabled = false;
+        c.ecs_enabled = false;
+        assert!(c.ensure_valid().is_err());
+    }
+
+    #[test]
+    fn toggle_refuses_to_disable_last_mode_and_reverts() {
+        let mut c = Config::default();
+        c.ecs_enabled = false; // only EC2 left enabled (direct set, no IO)
+        let result = c.toggle_ec2(); // would disable the last mode
+        assert!(result.is_err());
+        assert!(c.is_ec2_enabled()); // reverted in memory
+    }
+
+    #[test]
+    fn heal_reenables_both_when_both_disabled() {
+        let mut c = Config::default();
+        c.ec2_enabled = false;
+        c.ecs_enabled = false;
+        assert!(c.heal_disabled_modes());
+        assert!(c.is_ec2_enabled() && c.is_ecs_enabled());
+    }
+
+    #[test]
+    fn heal_is_noop_when_a_mode_is_enabled() {
+        let mut c = Config::default();
+        c.ecs_enabled = false; // ec2 still enabled
+        assert!(!c.heal_disabled_modes());
+        assert!(c.is_ec2_enabled());
+        assert!(!c.is_ecs_enabled());
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test config::tests 2>&1 | tail -20`
+Expected: FAIL — compile errors (`ec2_enabled`/`ecs_enabled` fields, `ensure_valid`, `toggle_ec2`, `is_ec2_enabled`, `heal_disabled_modes` don't exist yet).
+
+- [ ] **Step 3: Add the fields and a serde default helper**
+
+In `src/app/config.rs`, replace the `Config` struct definition:
+
+```rust
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Config {
+    recent_timeout: u64,
+    regions: HashMap<String, RegionConfig>,
+}
+```
+
+with:
+
+```rust
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Config {
+    recent_timeout: u64,
+    regions: HashMap<String, RegionConfig>,
+    #[serde(default = "default_true")]
+    ec2_enabled: bool,
+    #[serde(default = "default_true")]
+    ecs_enabled: bool,
+}
+```
+
+(The `#[serde(default = ...)]` makes existing `~/.sm_connect.json` files that predate these fields load fine, defaulting both to enabled.)
+
+- [ ] **Step 4: Default both flags to enabled**
+
+In the `impl Default for Config` block, change the returned struct literal from:
+
+```rust
+        Config {
+            regions,
+            recent_timeout: DEFAULT_RECENT_TIMEOUT,
+        }
+```
+
+to:
+
+```rust
+        Config {
+            regions,
+            recent_timeout: DEFAULT_RECENT_TIMEOUT,
+            ec2_enabled: true,
+            ecs_enabled: true,
+        }
+```
+
+- [ ] **Step 5: Add the write-gate to `persist()`**
+
+In `src/app/config.rs`, change the start of `persist()` from:
+
+```rust
+    pub fn persist(&self) -> Result<()> {
+        let config_path = Config::get_config_path()?;
+```
+
+to:
+
+```rust
+    pub fn persist(&self) -> Result<()> {
+        self.ensure_valid()?;
+        let config_path = Config::get_config_path()?;
+```
+
+Then add the `ensure_valid` helper (place it just above `persist`, inside `impl Config`):
+
+```rust
+    /// The single invariant gate, enforced on every write: at least one of the
+    /// EC2 / ECS modes must remain enabled. Checked before any filesystem IO.
+    fn ensure_valid(&self) -> Result<()> {
+        if !self.ec2_enabled && !self.ecs_enabled {
+            return Err(anyhow::anyhow!(
+                "at least one mode (EC2 or ECS) must remain enabled"
+            ));
+        }
+        Ok(())
+    }
+```
+
+- [ ] **Step 6: Add accessors, toggles, and the self-heal helper**
+
+Add these methods inside `impl Config` (e.g. after `ensure_valid`):
+
+```rust
+    pub fn is_ec2_enabled(&self) -> bool {
+        self.ec2_enabled
+    }
+
+    pub fn is_ecs_enabled(&self) -> bool {
+        self.ecs_enabled
+    }
+
+    /// Flips the EC2 flag and persists. If the write is rejected (would leave no
+    /// enabled mode), the flip is reverted and the error propagated.
+    pub fn toggle_ec2(&mut self) -> Result<()> {
+        self.ec2_enabled = !self.ec2_enabled;
+        if let Err(e) = self.persist() {
+            self.ec2_enabled = !self.ec2_enabled;
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    /// Flips the ECS flag and persists. If the write is rejected (would leave no
+    /// enabled mode), the flip is reverted and the error propagated.
+    pub fn toggle_ecs(&mut self) -> Result<()> {
+        self.ecs_enabled = !self.ecs_enabled;
+        if let Err(e) = self.persist() {
+            self.ecs_enabled = !self.ecs_enabled;
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    /// Repairs a hand-edited config that disabled both modes by re-enabling both.
+    /// Returns true if a change was made (so the caller can persist the fix).
+    fn heal_disabled_modes(&mut self) -> bool {
+        if !self.ec2_enabled && !self.ecs_enabled {
+            self.ec2_enabled = true;
+            self.ecs_enabled = true;
+            true
+        } else {
+            false
+        }
+    }
+```
+
+- [ ] **Step 7: Self-heal on load**
+
+In `Config::new`, change the deserialize-and-return block from:
+
+```rust
+        let config = match from_str(&contents) {
+            Ok(config) => config,
+            Err(_) => {
+                let config = Config::default();
+                config.persist()?;
+                config
+            }
+        };
+        Ok(Arc::new(Mutex::new(config)))
+```
+
+to:
+
+```rust
+        let mut config: Config = match from_str(&contents) {
+            Ok(config) => config,
+            Err(_) => {
+                let config = Config::default();
+                config.persist()?;
+                config
+            }
+        };
+        // Repair a hand-edited file that disabled both modes.
+        if config.heal_disabled_modes() {
+            config.persist()?;
+        }
+        Ok(Arc::new(Mutex::new(config)))
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `cargo test config::tests 2>&1 | tail -20`
+Expected: PASS — 4 tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/app/config.rs
+git commit -m "Add EC2/ECS mode flags with write-gate, toggles, and load self-heal
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: ConfigList — live-state toggle entries
+
+**Files:**
+- Modify: `src/components/config_list.rs`
+
+No unit test (this is rendering glue; the live-state label is verified in manual testing, Task 5). The real logic lives in `config.rs` (Task 1).
+
+- [ ] **Step 1: Add imports and the two new `ConfigOption` variants**
+
+In `src/components/config_list.rs`, add these imports near the top (below the existing `use` lines):
+
+```rust
+use crate::app::config::Config;
+use std::sync::{Arc, Mutex};
+```
+
+Change the `ConfigOption` enum from:
+
+```rust
+#[derive(Debug, Clone, Copy)]
+pub enum ConfigOption {
+    ResetRecent,
+    SetRecentTimeout,
+}
+```
+
+to:
+
+```rust
+#[derive(Debug, Clone, Copy)]
+pub enum ConfigOption {
+    ResetRecent,
+    SetRecentTimeout,
+    ToggleEc2,
+    ToggleEcs,
+}
+```
+
+- [ ] **Step 2: Remove the static `From<ConfigOption> for String` and expand the options array**
+
+Delete this block entirely (labels now come from a config-aware method):
+
+```rust
+impl From<ConfigOption> for String {
+    fn from(option: ConfigOption) -> String {
+        match option {
+            ConfigOption::ResetRecent => "Reset Recent Instances".to_string(),
+            ConfigOption::SetRecentTimeout => "Set Recent Timeout".to_string(),
+        }
+    }
+}
+```
+
+Change the options constant from:
+
+```rust
+const CONFIG_OPTIONS: [ConfigOption; 2] =
+    [ConfigOption::ResetRecent, ConfigOption::SetRecentTimeout];
+```
+
+to:
+
+```rust
+const CONFIG_OPTIONS: [ConfigOption; 4] = [
+    ConfigOption::ResetRecent,
+    ConfigOption::SetRecentTimeout,
+    ConfigOption::ToggleEc2,
+    ConfigOption::ToggleEcs,
+];
+```
+
+- [ ] **Step 3: Give `ConfigList` the config handle**
+
+Change the struct and `new` from:
+
+```rust
+#[derive(Debug)]
+pub struct ConfigList {
+    state: ListState,
+}
+
+impl ConfigList {
+    pub fn new() -> ConfigList {
+        let mut state = ListState::default();
+        state.select(Some(0));
+        ConfigList { state }
+    }
+```
+
+to:
+
+```rust
+#[derive(Debug)]
+pub struct ConfigList {
+    state: ListState,
+    config: Arc<Mutex<Config>>,
+}
+
+impl ConfigList {
+    pub fn new(config: Arc<Mutex<Config>>) -> ConfigList {
+        let mut state = ListState::default();
+        state.select(Some(0));
+        ConfigList { state, config }
+    }
+
+    /// Display label for an option. The mode toggles show their current state.
+    fn label(&self, option: ConfigOption) -> String {
+        match option {
+            ConfigOption::ResetRecent => "Reset Recent Instances".to_string(),
+            ConfigOption::SetRecentTimeout => "Set Recent Timeout".to_string(),
+            ConfigOption::ToggleEc2 => {
+                let enabled = self.config.lock().unwrap().is_ec2_enabled();
+                format!("EC2 mode: {}", if enabled { "enabled" } else { "disabled" })
+            }
+            ConfigOption::ToggleEcs => {
+                let enabled = self.config.lock().unwrap().is_ecs_enabled();
+                format!("ECS mode: {}", if enabled { "enabled" } else { "disabled" })
+            }
+        }
+    }
+```
+
+- [ ] **Step 4: Render labels via the new method**
+
+In `get_list`, change the item mapping from:
+
+```rust
+            .map(|i| {
+                let name: String = (*i).into();
+                ListItem::new(name)
+            })
+```
+
+to:
+
+```rust
+            .map(|i| {
+                let name = self.label(*i);
+                ListItem::new(name)
+            })
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cargo build 2>&1 | tail -20`
+Expected: builds. There will be an error at the `ConfigScreen::new` call site (`ConfigList::new()` now needs an argument) — that is fixed in Task 3. If `cargo build` errors ONLY about `ConfigList::new` arity in `config_screen.rs`, this task is correct. Confirm there are no other errors in `config_list.rs` itself.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/config_list.rs
+git commit -m "Add EC2/ECS mode toggle entries with live state to ConfigList
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: ConfigScreen — wire the toggles
+
+**Files:**
+- Modify: `src/screens/config_screen.rs`
+
+- [ ] **Step 1: Pass the config handle to `ConfigList`**
+
+In `ConfigScreen::new`, change:
+
+```rust
+        let config_list = ConfigList::new();
+```
+
+to:
+
+```rust
+        let config_list = ConfigList::new(config.clone());
+```
+
+(`config: Arc<Mutex<Config>>` is already a parameter of `ConfigScreen::new`.)
+
+- [ ] **Step 2: Handle the two toggle actions**
+
+In the `run` loop, the `ReturnConfig(option)` match currently has arms for `ResetRecent` and `SetRecentTimeout`. Add two arms so the match stays exhaustive over the four `ConfigOption` variants. Change:
+
+```rust
+                    Some(ConfigListOutputAction::ReturnConfig(option)) => match option {
+                        ConfigOption::ResetRecent => {
+                            History::reset().context("Failed to reset history")?;
+                            self.last_operation_success = Some(true);
+                        }
+                        ConfigOption::SetRecentTimeout => {
+                            self.modifying_action = Some(ConfigOption::SetRecentTimeout);
+                            self.input_active = true;
+                            let current_value = self.config.lock().unwrap().get_recent_timeout();
+                            self.input_component.set_value(current_value.to_string());
+                        }
+                    },
+```
+
+to:
+
+```rust
+                    Some(ConfigListOutputAction::ReturnConfig(option)) => match option {
+                        ConfigOption::ResetRecent => {
+                            History::reset().context("Failed to reset history")?;
+                            self.last_operation_success = Some(true);
+                        }
+                        ConfigOption::SetRecentTimeout => {
+                            self.modifying_action = Some(ConfigOption::SetRecentTimeout);
+                            self.input_active = true;
+                            let current_value = self.config.lock().unwrap().get_recent_timeout();
+                            self.input_component.set_value(current_value.to_string());
+                        }
+                        ConfigOption::ToggleEc2 => {
+                            // Success is silent (the list label flips); a refused
+                            // toggle (would disable the last mode) shows the failure banner.
+                            match self.config.lock().unwrap().toggle_ec2() {
+                                Ok(()) => self.last_operation_success = None,
+                                Err(_) => self.last_operation_success = Some(false),
+                            }
+                        }
+                        ConfigOption::ToggleEcs => {
+                            match self.config.lock().unwrap().toggle_ecs() {
+                                Ok(()) => self.last_operation_success = None,
+                                Err(_) => self.last_operation_success = Some(false),
+                            }
+                        }
+                    },
+```
+
+- [ ] **Step 2.5: Note on `get_recent_timeout`**
+
+`get_recent_timeout` is currently marked `#[allow(dead_code)]` in `config.rs` but is already called here — leave that attribute as-is; this task does not touch `config.rs`.
+
+- [ ] **Step 3: Verify it compiles and existing tests still pass**
+
+Run: `cargo build 2>&1 | tail -20 && cargo test 2>&1 | tail -6`
+Expected: builds with no errors; all tests pass (the 4 new config tests plus the pre-existing 8).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/screens/config_screen.rs
+git commit -m "Wire EC2/ECS mode toggles into the config screen
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Routing — skip Mode-Select for single-mode setups
+
+**Files:**
+- Modify: `src/app.rs`
+
+- [ ] **Step 1: Add imports and a `config` field on `App`**
+
+In `src/app.rs`, add this import (next to the other `use std::...` lines, e.g. after `use std::io::Stdout;`):
+
+```rust
+use std::sync::{Arc, Mutex};
+```
+
+Change the `App` struct from:
+
+```rust
+pub struct App {
+    terminal: Terminal<CrosstermBackend<Stdout>>,
+    selected_screen: SelectedScreen,
+    region_select_screen: RegionSelectScreen,
+    instance_selection_screen: InstanceSelectScreen,
+    task_select_screen: TaskSelectScreen,
+    selected_task: Option<EcsTaskInfo>,
+    config_screen: ConfigScreen,
+}
+```
+
+to (add the `config` field):
+
+```rust
+pub struct App {
+    terminal: Terminal<CrosstermBackend<Stdout>>,
+    selected_screen: SelectedScreen,
+    region_select_screen: RegionSelectScreen,
+    instance_selection_screen: InstanceSelectScreen,
+    task_select_screen: TaskSelectScreen,
+    selected_task: Option<EcsTaskInfo>,
+    config_screen: ConfigScreen,
+    config: Arc<Mutex<config::Config>>,
+}
+```
+
+In `App::new`, the local `config` already exists (`let config = config::Config::new()?;`, type `Arc<Mutex<Config>>`). Add it to the returned struct literal — change:
+
+```rust
+        Ok(App {
+            terminal,
+            selected_screen: SelectedScreen::RegionSelect,
+            region_select_screen,
+            instance_selection_screen,
+            task_select_screen,
+            selected_task: None,
+            config_screen,
+        })
+```
+
+to:
+
+```rust
+        Ok(App {
+            terminal,
+            selected_screen: SelectedScreen::RegionSelect,
+            region_select_screen,
+            instance_selection_screen,
+            task_select_screen,
+            selected_task: None,
+            config_screen,
+            config,
+        })
+```
+
+(`config` is moved into the struct last; the earlier `RegionSelectScreen::new(config.clone())` and `ConfigScreen::new(config.clone())` calls already clone it, so this is fine.)
+
+- [ ] **Step 2: Inline the mode-aware routing in the `RegionSelected` transition**
+
+In the `SelectedScreen::RegionSelect` arm, change:
+
+```rust
+                        region_select_screen::RegionSelectScreenOutcome::RegionSelected(region) => {
+                            self.selected_screen = SelectedScreen::ModeSelect(region);
+                        }
+```
+
+to:
+
+```rust
+                        region_select_screen::RegionSelectScreenOutcome::RegionSelected(region) => {
+                            let (ec2, ecs) = {
+                                let cfg = self.config.lock().unwrap();
+                                (cfg.is_ec2_enabled(), cfg.is_ecs_enabled())
+                            };
+                            self.selected_screen = match (ec2, ecs) {
+                                (true, false) => SelectedScreen::LoadingInstances(region),
+                                (false, true) => SelectedScreen::LoadingTasks(region),
+                                // both enabled (and the impossible both-disabled) -> show the picker
+                                _ => SelectedScreen::ModeSelect(region),
+                            };
+                        }
+```
+
+- [ ] **Step 3: Simplify the LoadingInstances cancel target**
+
+In the `SelectedScreen::LoadingInstances(region)` arm, change:
+
+```rust
+                        loading_instances_screen::LoadingInstancesScreenOutcome::Cancelled => {
+                            self.selected_screen = SelectedScreen::ModeSelect(region);
+                        }
+```
+
+to:
+
+```rust
+                        loading_instances_screen::LoadingInstancesScreenOutcome::Cancelled => {
+                            self.selected_screen = SelectedScreen::RegionSelect;
+                        }
+```
+
+- [ ] **Step 4: Simplify the LoadingTasks cancel target**
+
+In the `SelectedScreen::LoadingTasks(region)` arm, change:
+
+```rust
+                        LoadingTasksScreenOutcome::Cancelled => {
+                            self.selected_screen = SelectedScreen::ModeSelect(region);
+                        }
+```
+
+to:
+
+```rust
+                        LoadingTasksScreenOutcome::Cancelled => {
+                            self.selected_screen = SelectedScreen::RegionSelect;
+                        }
+```
+
+- [ ] **Step 5: Verify it compiles and tests pass**
+
+Run: `cargo build 2>&1 | tail -20 && cargo test 2>&1 | tail -6`
+Expected: builds; all 12 tests pass (8 pre-existing + 4 new config tests). Note: after Step 3/4, the `region` binding in those two arms is now only used for `LoadingInstancesScreen::new(region.clone())` / `LoadingTasksScreen::new(region.clone())` — no unused-variable warning is expected because the constructor still consumes it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app.rs
+git commit -m "Skip Mode-Select when only one mode is enabled; cancels return to Region
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Final build, lint, and manual verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full build + tests + clippy**
+
+Run: `cargo build 2>&1 | tail -3 && cargo test 2>&1 | tail -8 && cargo clippy 2>&1 | tail -5`
+Expected: clean build; 12 tests pass (8 existing + 4 new); no clippy warnings.
+
+- [ ] **Step 2: Manual verification (requires AWS credentials)**
+
+```bash
+export AWS_PROFILE=<a-profile>
+aws sso login
+cargo run
+```
+
+Verify, in order:
+1. With a fresh/default config (or both modes enabled), Region → Mode-Select appears as before.
+2. Open the config screen (`c` from the region list). Two new entries show live state: `EC2 mode: enabled`, `ECS mode: enabled`.
+3. Toggle `ECS mode` off — the label flips to `ECS mode: disabled` (no error banner).
+4. Try to toggle `EC2 mode` off too — it's refused: the red "Operation failed" banner shows and the label stays `EC2 mode: enabled`.
+5. Exit config, pick a region — Mode-Select is **skipped**, going straight to the EC2 instance loading/list.
+6. Cancel (Esc) on the loading spinner → returns to Region select.
+7. Re-enable ECS (and optionally disable EC2): with only ECS enabled, picking a region goes straight to the ECS task flow.
+8. Inspect `~/.sm_connect.json` — it contains `"ec2_enabled"` / `"ecs_enabled"`.
+9. Hand-edit the file setting both to `false`, save, relaunch — on load both are re-enabled (self-heal) and the file is rewritten with both `true`.
+
+- [ ] **Step 3: Confirm branch state**
+
+Run: `git status && git log --oneline -5`
+Expected: clean working tree; the four feature commits present on the `ecs` branch.
+
+---
+
+## Notes for the implementer
+
+- **Never** build with `--release` (CLAUDE.md).
+- The Task 1 tests are deliberately IO-free: `Config::default()` does no IO, private fields are set directly within the same-file test module, and the refusal test relies on `persist()` calling `ensure_valid()` *before* any filesystem access. Do not add tests that call a *successful* `toggle`/`persist` — that would write to the real `~/.sm_connect.json`.
+- This feature builds on the `ecs` branch (it depends on `ModeSelect`, `LoadingTasks`, etc.). Stay on `ecs`.
+- Out of scope (per spec): CLI flags for the toggles, per-region/per-profile preferences, and the direct `-r -i` CLI connect path (unaffected — it bypasses the TUI).

--- a/docs/superpowers/specs/2026-05-27-ecs-exec-design.md
+++ b/docs/superpowers/specs/2026-05-27-ecs-exec-design.md
@@ -107,10 +107,17 @@ the existing `run_aws_command` helper (so SIGINT/SIGTSTP pass-through still work
 ## Header (`src/components/header_tabs.rs`)
 
 The header "tabs" are really a flow/progress indicator, not interactive tabs. Make
-`HeaderTabs` accept its tab set so the ECS path shows its own steps
-(`Region / Mode / Tasks / Container`) while EC2 keeps `Region / Instances / Connection`.
-Two existing call sites (`region_select_screen`, `instance_select_screen`) are updated
-to pass their tab set.
+`HeaderTabs` accept its tab set so different screens can show different steps.
+
+- **ModeSelect** keeps the existing EC2 tab set (`Region / Instances / Connection`) —
+  no change to its appearance at the branch point.
+- The **ECS screens** (LoadingTasks / TaskSelect / ContainerSelect) switch to an
+  ECS-appropriate set (`Region / Tasks / Container`).
+
+This is an interim decision: the header's role as a progress indicator across two
+diverging flows is unresolved and **flagged for future revisiting**. Two existing call
+sites (`region_select_screen`, `instance_select_screen`) are updated to pass their tab
+set.
 
 ## Error handling
 

--- a/docs/superpowers/specs/2026-05-27-ecs-exec-design.md
+++ b/docs/superpowers/specs/2026-05-27-ecs-exec-design.md
@@ -1,0 +1,145 @@
+# ECS Exec Support — Design
+
+## Goal
+
+Let users connect into a running ECS task's container via `aws ecs execute-command`,
+alongside the existing EC2 / Session Manager flow. The interactive TUI gains a path:
+pick a region, choose the ECS mode, search the region's running tasks, pick a task,
+and (when needed) pick a container — then `sm_connect` shells out to the AWS CLI to
+open an interactive shell in that container.
+
+This mirrors the existing EC2 flow (`Region → LoadingInstances → InstanceSelect →
+connect`) rather than abstracting the working EC2 code into shared generics.
+
+## User flow
+
+```
+RegionSelect (existing)
+  └─> ModeSelect (NEW)
+        ├─ "EC2 (Session Manager)" ─> LoadingInstances → InstanceSelect → Connect/Tunnel/FileManager  (existing)
+        └─ "ECS (Exec)" ───────────> LoadingTasks (NEW) → TaskSelect (NEW) → ContainerSelect (NEW) → EcsExec
+```
+
+The final ECS action shells out to:
+
+```
+aws --region <REGION> ecs execute-command \
+  --cluster <CLUSTER> --task <TASK> --container <CONTAINER> \
+  --interactive --command "/bin/sh"
+```
+
+If the selected task has exactly **one** container, the ContainerSelect screen is
+skipped and exec starts immediately on that container.
+
+## Data model (`src/aws.rs`)
+
+New struct:
+
+```rust
+pub struct EcsTaskInfo {
+    region: Region,
+    cluster: String,          // cluster name or ARN (whatever execute-command accepts)
+    task_id: String,          // short id for display
+    task_arn: String,         // passed to --task
+    task_definition: String,  // family:revision, for display
+    service: String,          // ECS service name (from task `group`), for display; may be empty
+    last_status: String,      // e.g. RUNNING
+    containers: Vec<String>,  // container names; drives ContainerSelect
+}
+```
+
+Container names ride along on the task, so ContainerSelect needs no extra AWS call.
+
+New async fetch:
+
+```rust
+pub async fn fetch_ecs_tasks(region: Region) -> Result<Vec<EcsTaskInfo>>
+```
+
+Steps:
+1. `list_clusters` — enumerate all clusters in the region.
+2. For each cluster, `list_tasks` (paginated) with `desired_status = RUNNING`.
+3. `describe_tasks` in batches of ≤100 to pull `group` (service name), task definition,
+   `last_status`, and `containers[].name`.
+4. Flatten into `Vec<EcsTaskInfo>`.
+
+Uses `aws-sdk-ecs` (new dependency, sibling to the existing `aws-sdk-ec2`).
+
+## New screens (`src/screens/`)
+
+- **`mode_select_screen.rs`** — choose EC2 vs ECS. Returns which branch to take.
+- **`loading_tasks_screen.rs`** — mirrors `loading_instances_screen.rs`; spawns a
+  tokio task running `fetch_ecs_tasks`, drives the generic `Loader<Result<Vec<EcsTaskInfo>>>`.
+  Outcome: `Cancelled` | `TasksFetched(Vec<EcsTaskInfo>)`.
+- **`task_select_screen.rs`** — mirrors `instance_select_screen.rs`: a searchable table
+  plus the existing `TextInput` search overlay. Outcome: `Exit` | `Exec(EcsTaskInfo)`.
+- **`container_select_screen.rs`** — lists the selected task's containers.
+  Outcome: `Exit` | `Return(container_name)`.
+
+## New components (`src/components/`)
+
+- **`task_table.rs`** — modeled on `instance_table.rs`. Columns: Task ID,
+  Task Definition, Service, Status, Containers (count). Searchable/filterable across
+  those fields like the instance table. Output action: `ReturnTask(EcsTaskInfo)`,
+  plus `Search` / `Exit` to match the instance table's interaction model.
+- **`simple_list.rs`** — minimal single-select string list (up / down / enter / exit).
+  Reused by both `mode_select_screen` and `container_select_screen` to avoid
+  duplicating two near-identical list components.
+
+## `app.rs` wiring
+
+`SelectedScreen` gains: `ModeSelect`, `LoadingTasks(String /* region */)`,
+`TaskSelect`, `ContainerSelect`. After a region is chosen, `RegionSelect` now routes
+to `ModeSelect` (instead of straight to `LoadingInstances`). New match arms drive the
+ECS screens; the ECS task selected on `TaskSelect` is carried into `ContainerSelect`,
+and the resulting (task, container) becomes `UserAction::EcsExec`.
+
+New `UserAction` variant:
+
+```rust
+EcsExec { task: EcsTaskInfo, container: String }
+```
+
+`main.rs` gains the matching arm that builds and runs the `ecs execute-command` via
+the existing `run_aws_command` helper (so SIGINT/SIGTSTP pass-through still works).
+
+## Header (`src/components/header_tabs.rs`)
+
+The header "tabs" are really a flow/progress indicator, not interactive tabs. Make
+`HeaderTabs` accept its tab set so the ECS path shows its own steps
+(`Region / Mode / Tasks / Container`) while EC2 keeps `Region / Instances / Connection`.
+Two existing call sites (`region_select_screen`, `instance_select_screen`) are updated
+to pass their tab set.
+
+## Error handling
+
+- `fetch_ecs_tasks` returns `Result`; the loader screen surfaces failures the same way
+  `loading_instances_screen` does ("Failed to fetch tasks. Check your AWS credentials.").
+- ECS exec prerequisites (`enableExecuteCommand` on the service/task, task-role IAM
+  permissions, the SSM Session Manager plugin) are **not** pre-validated; if they are
+  missing the AWS CLI prints its own error after `sm_connect` exits the TUI. This
+  matches how the EC2 path already defers to the CLI.
+
+## Testing
+
+- Follow the repo's existing testing conventions (the EC2 screens/components are not
+  unit-tested; logic-bearing helpers such as `fetch_ecs_tasks` flattening and the
+  task-table filter are the candidates for targeted tests if the codebase supports it).
+- Manual verification: run against a real account with at least one ECS cluster that
+  has exec-enabled tasks; confirm region → mode → tasks → container → shell works,
+  and that the single-container auto-skip behaves.
+
+## Documentation
+
+Update `README.md`: add ECS exec to the feature description and add an ECS exec
+prerequisites note (`enableExecuteCommand`, task-role IAM, SSM Session Manager plugin).
+
+## Out of scope (v1)
+
+- **Configurable exec command** — hardcoded `/bin/sh`. CLI/config override is a later
+  addition.
+- **Direct ECS CLI args** (`--cluster` / `--task` / `--container`) — interactive flow
+  only for now.
+- **History / last-access for ECS** — task IDs are ephemeral, so last-access sorting
+  is not meaningful; omitted.
+- **ECS port-forwarding / tunnel / file-manager** for tasks — EC2-only for now.

--- a/docs/superpowers/specs/2026-05-27-ecs-exec-design.md
+++ b/docs/superpowers/specs/2026-05-27-ecs-exec-design.md
@@ -38,7 +38,8 @@ New struct:
 ```rust
 pub struct EcsTaskInfo {
     region: Region,
-    cluster: String,          // cluster name or ARN (whatever execute-command accepts)
+    cluster: String,          // cluster name or ARN (whatever execute-command accepts);
+                              //   the Cluster column displays the short name parsed from the ARN
     task_id: String,          // short id for display
     task_arn: String,         // passed to --task
     task_definition: String,  // family:revision, for display
@@ -78,7 +79,7 @@ Uses `aws-sdk-ecs` (new dependency, sibling to the existing `aws-sdk-ec2`).
 
 ## New components (`src/components/`)
 
-- **`task_table.rs`** — modeled on `instance_table.rs`. Columns: Task ID,
+- **`task_table.rs`** — modeled on `instance_table.rs`. Columns: Cluster, Task ID,
   Task Definition, Service, Status, Containers (count). Searchable/filterable across
   those fields like the instance table. Output action: `ReturnTask(EcsTaskInfo)`,
   plus `Search` / `Exit` to match the instance table's interaction model.

--- a/docs/superpowers/specs/2026-05-27-mode-toggle-design.md
+++ b/docs/superpowers/specs/2026-05-27-mode-toggle-design.md
@@ -1,0 +1,134 @@
+# Configurable EC2 / ECS Mode Toggle — Design
+
+## Goal
+
+Let users disable the EC2 (Session Manager) or ECS (Exec) mode they don't use, via
+persistent config. When only one mode is enabled, the interactive flow skips the
+Mode-Select screen and goes straight into that mode after region selection.
+
+Builds on the ECS Exec feature (the `ecs` branch) — it depends on the `ModeSelect`
+screen and the EC2/ECS branch existing.
+
+## Behavior
+
+- Both modes enabled (default): unchanged — Region → Mode-Select → chosen flow.
+- One mode disabled: Region → straight into the enabled mode's flow (Mode-Select is
+  never rendered). Disabling a mode actually saves a step.
+- The "both disabled" state is forbidden (see invariant below).
+
+## Config (`src/app/config.rs`)
+
+Add two fields to `Config`:
+
+```rust
+ec2_enabled: bool,  // default true
+ecs_enabled: bool,  // default true
+```
+
+- Serialized with serde. Both use `#[serde(default = "default_true")]` so existing
+  `~/.sm_connect.json` files written before this feature load fine and default to
+  enabled. `Default for Config` also sets both to `true`.
+
+### Invariant enforced at write time
+
+`Config::persist()` is the single gatekeeper. At the top of `persist()`:
+
+```rust
+if !self.ec2_enabled && !self.ecs_enabled {
+    return Err(anyhow!("at least one mode (EC2 or ECS) must remain enabled"));
+}
+```
+
+Nothing is written when this trips. Since no other setter touches the mode flags, this
+only ever blocks a both-off write. The invariant lives in the data layer, not the UI.
+
+### Methods
+
+```rust
+pub fn is_ec2_enabled(&self) -> bool
+pub fn is_ecs_enabled(&self) -> bool
+pub fn toggle_ec2(&mut self) -> Result<()>
+pub fn toggle_ecs(&mut self) -> Result<()>
+```
+
+Each toggle flips its flag in memory, calls `persist()`, and **reverts the flip if
+persist returns `Err`**, propagating the error. The toggle contains no invariant logic
+— it just undoes a rejected write:
+
+```rust
+pub fn toggle_ecs(&mut self) -> Result<()> {
+    self.ecs_enabled = !self.ecs_enabled;
+    if let Err(e) = self.persist() {
+        self.ecs_enabled = !self.ecs_enabled; // revert
+        return Err(e);
+    }
+    Ok(())
+}
+```
+
+### Load-time self-heal
+
+A hand-edited config with both flags `false` is repaired on load. In `Config::new`,
+after deserializing, if `!ec2_enabled && !ecs_enabled`, set both to `true` and persist
+(which passes the gate, since we're writing both-on). This does not fight the write
+gate — the gate only rejects writes that would *store* both-off.
+
+## Config screen (`src/components/config_list.rs`, `src/screens/config_screen.rs`)
+
+Two new `ConfigOption` entries with live state in the label, e.g.:
+
+```
+EC2 mode: enabled
+ECS mode: disabled
+```
+
+- `ConfigList` takes the `Arc<Mutex<Config>>` handle (the same way `RegionList` already
+  does) so it can render the current on/off state in those two labels.
+- Pressing Enter on an entry calls `config.toggle_ec2()` / `toggle_ecs()`.
+- On `Ok`, the list re-renders with the flipped state. On `Err` (refused — would
+  disable the last mode), reuse the existing red "Operation failed" banner
+  (`last_operation_success = Some(false)`). No invariant logic in the screen.
+
+## Routing (`src/app.rs`)
+
+Add a `config: Arc<Mutex<Config>>` field to `App` (cloned from the same handle already
+shared with the region/config screens).
+
+Replace the `RegionSelected(region)` transition (currently always `ModeSelect(region)`)
+with an inline match on the enabled modes:
+
+```rust
+RegionSelectScreenOutcome::RegionSelected(region) => {
+    let cfg = self.config.lock().unwrap();
+    self.selected_screen = match (cfg.is_ec2_enabled(), cfg.is_ecs_enabled()) {
+        (true, false) => SelectedScreen::LoadingInstances(region),
+        (false, true) => SelectedScreen::LoadingTasks(region),
+        _             => SelectedScreen::ModeSelect(region), // both (none is impossible)
+    };
+}
+```
+
+Loading-screen cancels are simplified to always return to `RegionSelect`:
+
+- `LoadingInstancesScreenOutcome::Cancelled` → `RegionSelect` (was `ModeSelect`)
+- `LoadingTasksScreenOutcome::Cancelled` → `RegionSelect` (was `ModeSelect`)
+
+`InstanceSelect` / `TaskSelect` exit already go to `RegionSelect` — unchanged. With all
+cancels/exits returning to Region, no skip-induced loop is possible and the config check
+exists in exactly one place.
+
+## Testing
+
+Unit tests on `src/app/config.rs` (pure logic, no AWS/TUI):
+
+- `persist` (or a toggle through it) rejects disabling the last enabled mode, and the
+  in-memory flag is reverted to its prior value.
+- Toggling a mode while the other stays enabled succeeds and flips state.
+- Load-time self-heal: a config with both flags false ends up with both true.
+
+## Out of scope
+
+- CLI flags to set the toggles (config + config screen only).
+- Per-region or per-profile mode preferences (global only).
+- Changing the direct `-r -i` CLI connect path (it bypasses the TUI entirely and is
+  unaffected).

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,10 +1,15 @@
 use crate::aws::InstanceInfo;
+use crate::aws::EcsTaskInfo;
 
 use crate::screens::Screen;
 use crate::screens::config_screen::ConfigScreen;
+use crate::screens::container_select_screen::{ContainerSelectScreen, ContainerSelectScreenOutcome};
 use crate::screens::instance_select_screen::InstanceSelectScreen;
 use crate::screens::loading_instances_screen::LoadingInstancesScreen;
+use crate::screens::loading_tasks_screen::{LoadingTasksScreen, LoadingTasksScreenOutcome};
+use crate::screens::mode_select_screen::{ModeSelectScreen, ModeSelectScreenOutcome};
 use crate::screens::region_select_screen::RegionSelectScreen;
+use crate::screens::task_select_screen::{TaskSelectScreen, TaskSelectScreenOutcome};
 use crate::screens::{loading_instances_screen, region_select_screen};
 use crate::ui::restore_terminal;
 use crate::ui::setup_terminal;
@@ -23,13 +28,18 @@ pub enum UserAction {
     Connect(InstanceInfo),
     Tunnel(InstanceInfo),
     FileManager(InstanceInfo),
+    EcsExec { task: EcsTaskInfo, container: String },
 }
 
 #[derive(Debug, Clone)]
 pub enum SelectedScreen {
     RegionSelect,
+    ModeSelect(String),
     LoadingInstances(String),
     InstanceSelect,
+    LoadingTasks(String),
+    TaskSelect,
+    ContainerSelect,
     Config,
 }
 
@@ -38,6 +48,8 @@ pub struct App {
     selected_screen: SelectedScreen,
     region_select_screen: RegionSelectScreen,
     instance_selection_screen: InstanceSelectScreen,
+    task_select_screen: TaskSelectScreen,
+    selected_task: Option<EcsTaskInfo>,
     config_screen: ConfigScreen,
 }
 
@@ -47,12 +59,15 @@ impl App {
         let config = config::Config::new()?;
         let region_select_screen = RegionSelectScreen::new(config.clone());
         let instance_selection_screen = InstanceSelectScreen::new();
+        let task_select_screen = TaskSelectScreen::new();
         let config_screen = ConfigScreen::new(config.clone());
         Ok(App {
             terminal,
             selected_screen: SelectedScreen::RegionSelect,
             region_select_screen,
             instance_selection_screen,
+            task_select_screen,
+            selected_task: None,
             config_screen,
         })
     }
@@ -66,7 +81,7 @@ impl App {
                     match self.region_select_screen.run(&mut self.terminal)? {
                         region_select_screen::RegionSelectScreenOutcome::Exit => should_exit = true,
                         region_select_screen::RegionSelectScreenOutcome::RegionSelected(region) => {
-                            self.selected_screen = SelectedScreen::LoadingInstances(region);
+                            self.selected_screen = SelectedScreen::ModeSelect(region);
                         }
                         region_select_screen::RegionSelectScreenOutcome::OpenConfig => {
                             self.selected_screen = SelectedScreen::Config;
@@ -74,9 +89,9 @@ impl App {
                     }
                 }
                 SelectedScreen::LoadingInstances(region) => {
-                    match LoadingInstancesScreen::new(region).run(&mut self.terminal)? {
+                    match LoadingInstancesScreen::new(region.clone()).run(&mut self.terminal)? {
                         loading_instances_screen::LoadingInstancesScreenOutcome::Cancelled => {
-                            self.selected_screen = SelectedScreen::RegionSelect;
+                            self.selected_screen = SelectedScreen::ModeSelect(region);
                         }
                         loading_instances_screen::LoadingInstancesScreenOutcome::InstancesFetched(instances) => {
                             self.instance_selection_screen.set_instances(instances);
@@ -106,6 +121,63 @@ impl App {
                         ) => {
                             should_exit = true;
                             return_value = Some(UserAction::FileManager(instance_info));
+                        }
+                    }
+                }
+                SelectedScreen::ModeSelect(region) => {
+                    match ModeSelectScreen::new().run(&mut self.terminal)? {
+                        ModeSelectScreenOutcome::Exit => {
+                            self.selected_screen = SelectedScreen::RegionSelect;
+                        }
+                        ModeSelectScreenOutcome::Ec2 => {
+                            self.selected_screen = SelectedScreen::LoadingInstances(region);
+                        }
+                        ModeSelectScreenOutcome::Ecs => {
+                            self.selected_screen = SelectedScreen::LoadingTasks(region);
+                        }
+                    }
+                }
+                SelectedScreen::LoadingTasks(region) => {
+                    match LoadingTasksScreen::new(region.clone()).run(&mut self.terminal)? {
+                        LoadingTasksScreenOutcome::Cancelled => {
+                            self.selected_screen = SelectedScreen::ModeSelect(region);
+                        }
+                        LoadingTasksScreenOutcome::TasksFetched(tasks) => {
+                            self.task_select_screen.set_tasks(tasks);
+                            self.selected_screen = SelectedScreen::TaskSelect;
+                        }
+                    }
+                }
+                SelectedScreen::TaskSelect => {
+                    match self.task_select_screen.run(&mut self.terminal)? {
+                        TaskSelectScreenOutcome::Exit => {
+                            self.selected_screen = SelectedScreen::RegionSelect;
+                        }
+                        TaskSelectScreenOutcome::Exec(task) => {
+                            if task.get_containers().len() == 1 {
+                                let container = task.get_containers()[0].clone();
+                                should_exit = true;
+                                return_value = Some(UserAction::EcsExec { task, container });
+                            } else {
+                                self.selected_task = Some(task);
+                                self.selected_screen = SelectedScreen::ContainerSelect;
+                            }
+                        }
+                    }
+                }
+                SelectedScreen::ContainerSelect => {
+                    let task = self
+                        .selected_task
+                        .clone()
+                        .expect("ContainerSelect requires a selected task");
+                    let containers = task.get_containers().to_vec();
+                    match ContainerSelectScreen::new(containers).run(&mut self.terminal)? {
+                        ContainerSelectScreenOutcome::Exit => {
+                            self.selected_screen = SelectedScreen::TaskSelect;
+                        }
+                        ContainerSelectScreenOutcome::Return(container) => {
+                            should_exit = true;
+                            return_value = Some(UserAction::EcsExec { task, container });
                         }
                     }
                 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,6 +18,7 @@ use anyhow::Context;
 use ratatui::prelude::*;
 
 use std::io::Stdout;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 
@@ -51,6 +52,7 @@ pub struct App {
     task_select_screen: TaskSelectScreen,
     selected_task: Option<EcsTaskInfo>,
     config_screen: ConfigScreen,
+    config: Arc<Mutex<config::Config>>,
 }
 
 impl App {
@@ -69,6 +71,7 @@ impl App {
             task_select_screen,
             selected_task: None,
             config_screen,
+            config,
         })
     }
 
@@ -81,7 +84,16 @@ impl App {
                     match self.region_select_screen.run(&mut self.terminal)? {
                         region_select_screen::RegionSelectScreenOutcome::Exit => should_exit = true,
                         region_select_screen::RegionSelectScreenOutcome::RegionSelected(region) => {
-                            self.selected_screen = SelectedScreen::ModeSelect(region);
+                            let (ec2, ecs) = {
+                                let cfg = self.config.lock().unwrap();
+                                (cfg.is_ec2_enabled(), cfg.is_ecs_enabled())
+                            };
+                            self.selected_screen = match (ec2, ecs) {
+                                (true, false) => SelectedScreen::LoadingInstances(region),
+                                (false, true) => SelectedScreen::LoadingTasks(region),
+                                // both enabled (and the impossible both-disabled) -> show the picker
+                                _ => SelectedScreen::ModeSelect(region),
+                            };
                         }
                         region_select_screen::RegionSelectScreenOutcome::OpenConfig => {
                             self.selected_screen = SelectedScreen::Config;
@@ -91,7 +103,7 @@ impl App {
                 SelectedScreen::LoadingInstances(region) => {
                     match LoadingInstancesScreen::new(region.clone()).run(&mut self.terminal)? {
                         loading_instances_screen::LoadingInstancesScreenOutcome::Cancelled => {
-                            self.selected_screen = SelectedScreen::ModeSelect(region);
+                            self.selected_screen = SelectedScreen::RegionSelect;
                         }
                         loading_instances_screen::LoadingInstancesScreenOutcome::InstancesFetched(instances) => {
                             self.instance_selection_screen.set_instances(instances);
@@ -140,7 +152,7 @@ impl App {
                 SelectedScreen::LoadingTasks(region) => {
                     match LoadingTasksScreen::new(region.clone()).run(&mut self.terminal)? {
                         LoadingTasksScreenOutcome::Cancelled => {
-                            self.selected_screen = SelectedScreen::ModeSelect(region);
+                            self.selected_screen = SelectedScreen::RegionSelect;
                         }
                         LoadingTasksScreenOutcome::TasksFetched(tasks) => {
                             self.task_select_screen.set_tasks(tasks);

--- a/src/app.rs
+++ b/src/app.rs
@@ -151,6 +151,8 @@ impl App {
                 SelectedScreen::TaskSelect => {
                     match self.task_select_screen.run(&mut self.terminal)? {
                         TaskSelectScreenOutcome::Exit => {
+                            // Exiting the list starts over at region select, matching the
+                            // EC2 path (InstanceSelect Exit also returns to RegionSelect).
                             self.selected_screen = SelectedScreen::RegionSelect;
                         }
                         TaskSelectScreenOutcome::Exec(task) => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -101,7 +101,7 @@ impl App {
                     }
                 }
                 SelectedScreen::LoadingInstances(region) => {
-                    match LoadingInstancesScreen::new(region.clone()).run(&mut self.terminal)? {
+                    match LoadingInstancesScreen::new(region).run(&mut self.terminal)? {
                         loading_instances_screen::LoadingInstancesScreenOutcome::Cancelled => {
                             self.selected_screen = SelectedScreen::RegionSelect;
                         }
@@ -150,7 +150,7 @@ impl App {
                     }
                 }
                 SelectedScreen::LoadingTasks(region) => {
-                    match LoadingTasksScreen::new(region.clone()).run(&mut self.terminal)? {
+                    match LoadingTasksScreen::new(region).run(&mut self.terminal)? {
                         LoadingTasksScreenOutcome::Cancelled => {
                             self.selected_screen = SelectedScreen::RegionSelect;
                         }

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -18,6 +18,7 @@ struct RegionConfig {
 // when it becomes stable as const , switch to Duration::from_days(7).as_secs();
 // https://github.com/rust-lang/rust/issues/120301
 const DEFAULT_RECENT_TIMEOUT: u64 = 60 * 60 * 24 * 7;
+
 fn default_true() -> bool {
     true
 }

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -193,9 +193,9 @@ impl Config {
         self.recent_timeout
     }
     #[allow(dead_code)]
-    pub fn set_recent_timeout(&mut self, timeout: u64) -> Result<()> {
+    pub fn set_recent_timeout(&mut self, timeout: u64) {
+        // In-memory only; the config menu persists once on exit.
         self.recent_timeout = timeout;
-        self.persist()
     }
 
     pub fn is_ec2_enabled(&self) -> bool {
@@ -206,26 +206,16 @@ impl Config {
         self.ecs_enabled
     }
 
-    /// Flips the EC2 flag and persists. If the write is rejected (would leave no
-    /// enabled mode), the flip is reverted and the error propagated.
-    pub fn toggle_ec2(&mut self) -> Result<()> {
+    /// Flips the EC2 flag in memory. Both modes may be off transiently while the
+    /// user reorganizes; the "at least one enabled" invariant is enforced on
+    /// persist (the config menu persists on exit).
+    pub fn toggle_ec2(&mut self) {
         self.ec2_enabled = !self.ec2_enabled;
-        if let Err(e) = self.persist() {
-            self.ec2_enabled = !self.ec2_enabled;
-            return Err(e);
-        }
-        Ok(())
     }
 
-    /// Flips the ECS flag and persists. If the write is rejected (would leave no
-    /// enabled mode), the flip is reverted and the error propagated.
-    pub fn toggle_ecs(&mut self) -> Result<()> {
+    /// Flips the ECS flag in memory. See `toggle_ec2` for why this can't fail.
+    pub fn toggle_ecs(&mut self) {
         self.ecs_enabled = !self.ecs_enabled;
-        if let Err(e) = self.persist() {
-            self.ecs_enabled = !self.ecs_enabled;
-            return Err(e);
-        }
-        Ok(())
     }
 
     /// Repairs a hand-edited config that disabled both modes by re-enabling both.
@@ -255,12 +245,14 @@ mod tests {
     }
 
     #[test]
-    fn toggle_refuses_to_disable_last_mode_and_reverts() {
+    fn toggles_can_leave_both_modes_off_in_memory() {
         let mut c = Config::default();
-        c.ecs_enabled = false; // only EC2 left enabled (direct set, no IO)
-        let result = c.toggle_ec2(); // would disable the last mode
-        assert!(result.is_err());
-        assert!(c.is_ec2_enabled()); // reverted in memory
+        c.toggle_ec2(); // ec2 off, ecs still on
+        c.toggle_ecs(); // both off — allowed transiently
+        assert!(!c.is_ec2_enabled());
+        assert!(!c.is_ecs_enabled());
+        // The invariant is enforced only on persist, not on the toggle.
+        assert!(c.ensure_valid().is_err());
     }
 
     #[test]

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -18,10 +18,18 @@ struct RegionConfig {
 // when it becomes stable as const , switch to Duration::from_days(7).as_secs();
 // https://github.com/rust-lang/rust/issues/120301
 const DEFAULT_RECENT_TIMEOUT: u64 = 60 * 60 * 24 * 7;
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
     recent_timeout: u64,
     regions: HashMap<String, RegionConfig>,
+    #[serde(default = "default_true")]
+    ec2_enabled: bool,
+    #[serde(default = "default_true")]
+    ecs_enabled: bool,
 }
 
 impl Default for Config {
@@ -33,6 +41,8 @@ impl Default for Config {
         Config {
             regions,
             recent_timeout: DEFAULT_RECENT_TIMEOUT,
+            ec2_enabled: true,
+            ecs_enabled: true,
         }
     }
 }
@@ -82,7 +92,7 @@ impl Config {
 
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
-        let config = match from_str(&contents) {
+        let mut config: Config = match from_str(&contents) {
             Ok(config) => config,
             Err(_) => {
                 let config = Config::default();
@@ -90,10 +100,26 @@ impl Config {
                 config
             }
         };
+        // Repair a hand-edited file that disabled both modes.
+        if config.heal_disabled_modes() {
+            config.persist()?;
+        }
         Ok(Arc::new(Mutex::new(config)))
     }
 
+    /// The single invariant gate, enforced on every write: at least one of the
+    /// EC2 / ECS modes must remain enabled. Checked before any filesystem IO.
+    fn ensure_valid(&self) -> Result<()> {
+        if !self.ec2_enabled && !self.ecs_enabled {
+            return Err(anyhow::anyhow!(
+                "at least one mode (EC2 or ECS) must remain enabled"
+            ));
+        }
+        Ok(())
+    }
+
     pub fn persist(&self) -> Result<()> {
+        self.ensure_valid()?;
         let config_path = Config::get_config_path()?;
         let mut file = std::fs::OpenOptions::new()
             .create(true)
@@ -169,5 +195,88 @@ impl Config {
     pub fn set_recent_timeout(&mut self, timeout: u64) -> Result<()> {
         self.recent_timeout = timeout;
         self.persist()
+    }
+
+    pub fn is_ec2_enabled(&self) -> bool {
+        self.ec2_enabled
+    }
+
+    pub fn is_ecs_enabled(&self) -> bool {
+        self.ecs_enabled
+    }
+
+    /// Flips the EC2 flag and persists. If the write is rejected (would leave no
+    /// enabled mode), the flip is reverted and the error propagated.
+    pub fn toggle_ec2(&mut self) -> Result<()> {
+        self.ec2_enabled = !self.ec2_enabled;
+        if let Err(e) = self.persist() {
+            self.ec2_enabled = !self.ec2_enabled;
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    /// Flips the ECS flag and persists. If the write is rejected (would leave no
+    /// enabled mode), the flip is reverted and the error propagated.
+    pub fn toggle_ecs(&mut self) -> Result<()> {
+        self.ecs_enabled = !self.ecs_enabled;
+        if let Err(e) = self.persist() {
+            self.ecs_enabled = !self.ecs_enabled;
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    /// Repairs a hand-edited config that disabled both modes by re-enabling both.
+    /// Returns true if a change was made (so the caller can persist the fix).
+    fn heal_disabled_modes(&mut self) -> bool {
+        if !self.ec2_enabled && !self.ecs_enabled {
+            self.ec2_enabled = true;
+            self.ecs_enabled = true;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_valid_rejects_both_disabled() {
+        let mut c = Config::default();
+        assert!(c.ensure_valid().is_ok()); // both enabled by default
+        c.ec2_enabled = false;
+        c.ecs_enabled = false;
+        assert!(c.ensure_valid().is_err());
+    }
+
+    #[test]
+    fn toggle_refuses_to_disable_last_mode_and_reverts() {
+        let mut c = Config::default();
+        c.ecs_enabled = false; // only EC2 left enabled (direct set, no IO)
+        let result = c.toggle_ec2(); // would disable the last mode
+        assert!(result.is_err());
+        assert!(c.is_ec2_enabled()); // reverted in memory
+    }
+
+    #[test]
+    fn heal_reenables_both_when_both_disabled() {
+        let mut c = Config::default();
+        c.ec2_enabled = false;
+        c.ecs_enabled = false;
+        assert!(c.heal_disabled_modes());
+        assert!(c.is_ec2_enabled() && c.is_ecs_enabled());
+    }
+
+    #[test]
+    fn heal_is_noop_when_a_mode_is_enabled() {
+        let mut c = Config::default();
+        c.ecs_enabled = false; // ec2 still enabled
+        assert!(!c.heal_disabled_modes());
+        assert!(c.is_ec2_enabled());
+        assert!(!c.is_ecs_enabled());
     }
 }

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -219,8 +219,21 @@ pub async fn fetch_ecs_tasks(region: Region) -> Result<Vec<EcsTaskInfo>> {
         .await;
     let client = aws_sdk_ecs::Client::new(&config);
 
-    let clusters = client.list_clusters().send().await?;
-    let cluster_arns = clusters.cluster_arns.unwrap_or_default();
+    // Enumerate clusters, following pagination (ListClusters returns <=100 per page).
+    let mut cluster_arns: Vec<String> = Vec::new();
+    let mut clusters_token: Option<String> = None;
+    loop {
+        let resp = client
+            .list_clusters()
+            .set_next_token(clusters_token)
+            .send()
+            .await?;
+        cluster_arns.extend(resp.cluster_arns.unwrap_or_default());
+        clusters_token = resp.next_token;
+        if clusters_token.is_none() {
+            break;
+        }
+    }
 
     let mut tasks: Vec<EcsTaskInfo> = Vec::new();
 
@@ -251,6 +264,8 @@ pub async fn fetch_ecs_tasks(region: Region) -> Result<Vec<EcsTaskInfo>> {
                 .set_tasks(Some(chunk.to_vec()))
                 .send()
                 .await?;
+            // `described.failures` is intentionally ignored: a task that stopped
+            // between list_tasks and describe_tasks simply won't appear in the list.
             for task in described.tasks.unwrap_or_default() {
                 let task_arn = task.task_arn.clone().unwrap_or_default();
                 let task_definition_arn = task.task_definition_arn.clone().unwrap_or_default();

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -143,7 +143,7 @@ impl EcsTaskInfo {
         &self.cluster
     }
 
-    pub fn cluster_name(&self) -> &str {
+    pub fn get_cluster_name(&self) -> &str {
         &self.cluster_name
     }
 
@@ -244,7 +244,7 @@ mod tests {
             "RUNNING".to_string(),
             vec!["app".to_string(), "sidecar".to_string()],
         );
-        assert_eq!(task.cluster_name(), "prod");
+        assert_eq!(task.get_cluster_name(), "prod");
         assert_eq!(task.get_task_id(), "deadbeef");
         assert_eq!(task.get_task_definition(), "web:7");
         assert_eq!(task.get_service(), "web-api");

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -6,6 +6,7 @@ use aws_sdk_ec2::{
     Client,
     types::{Filter, Instance},
 };
+use aws_sdk_ecs::types::DesiredStatus;
 
 use crate::history::History;
 
@@ -205,6 +206,76 @@ pub async fn fetch_instances(region: Region) -> Result<Vec<InstanceInfo>> {
         })
         .collect();
     Ok(instances)
+}
+
+/// Enumerates all RUNNING ECS tasks across every cluster in the region.
+///
+/// Steps: list clusters -> for each cluster list RUNNING task ARNs (paginated) ->
+/// describe those tasks in batches of <=100 to pull group/definition/status/containers.
+pub async fn fetch_ecs_tasks(region: Region) -> Result<Vec<EcsTaskInfo>> {
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .region(region.clone())
+        .load()
+        .await;
+    let client = aws_sdk_ecs::Client::new(&config);
+
+    let clusters = client.list_clusters().send().await?;
+    let cluster_arns = clusters.cluster_arns.unwrap_or_default();
+
+    let mut tasks: Vec<EcsTaskInfo> = Vec::new();
+
+    for cluster_arn in cluster_arns {
+        // Collect RUNNING task ARNs for this cluster, following pagination.
+        let mut task_arns: Vec<String> = Vec::new();
+        let mut next_token: Option<String> = None;
+        loop {
+            let resp = client
+                .list_tasks()
+                .cluster(&cluster_arn)
+                .desired_status(DesiredStatus::Running)
+                .set_next_token(next_token)
+                .send()
+                .await?;
+            task_arns.extend(resp.task_arns.unwrap_or_default());
+            next_token = resp.next_token;
+            if next_token.is_none() {
+                break;
+            }
+        }
+
+        // describe_tasks accepts at most 100 task ARNs per call.
+        for chunk in task_arns.chunks(100) {
+            let described = client
+                .describe_tasks()
+                .cluster(&cluster_arn)
+                .set_tasks(Some(chunk.to_vec()))
+                .send()
+                .await?;
+            for task in described.tasks.unwrap_or_default() {
+                let task_arn = task.task_arn.clone().unwrap_or_default();
+                let task_definition_arn = task.task_definition_arn.clone().unwrap_or_default();
+                let group = task.group.clone().unwrap_or_default();
+                let last_status = task.last_status.clone().unwrap_or_default();
+                let containers = task
+                    .containers
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(|c| c.name)
+                    .collect();
+                tasks.push(EcsTaskInfo::new(
+                    region.clone(),
+                    cluster_arn.clone(),
+                    task_arn,
+                    task_definition_arn,
+                    group,
+                    last_status,
+                    containers,
+                ));
+            }
+        }
+    }
+
+    Ok(tasks)
 }
 
 #[cfg(test)]

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -271,12 +271,17 @@ pub async fn fetch_ecs_tasks(region: Region) -> Result<Vec<EcsTaskInfo>> {
                 let task_definition_arn = task.task_definition_arn.clone().unwrap_or_default();
                 let group = task.group.clone().unwrap_or_default();
                 let last_status = task.last_status.clone().unwrap_or_default();
-                let containers = task
+                let containers: Vec<String> = task
                     .containers
                     .unwrap_or_default()
                     .into_iter()
                     .filter_map(|c| c.name)
                     .collect();
+                // A task with no named containers can't be exec'd into; skip it
+                // so it never shows up as an unusable row / empty container picker.
+                if containers.is_empty() {
+                    continue;
+                }
                 tasks.push(EcsTaskInfo::new(
                     region.clone(),
                     cluster_arn.clone(),

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -219,41 +219,27 @@ pub async fn fetch_ecs_tasks(region: Region) -> Result<Vec<EcsTaskInfo>> {
         .await;
     let client = aws_sdk_ecs::Client::new(&config);
 
-    // Enumerate clusters, following pagination (ListClusters returns <=100 per page).
+    // Enumerate clusters across all pages via the SDK paginator.
     let mut cluster_arns: Vec<String> = Vec::new();
-    let mut clusters_token: Option<String> = None;
-    loop {
-        let resp = client
-            .list_clusters()
-            .set_next_token(clusters_token)
-            .send()
-            .await?;
-        cluster_arns.extend(resp.cluster_arns.unwrap_or_default());
-        clusters_token = resp.next_token;
-        if clusters_token.is_none() {
-            break;
-        }
+    let mut cluster_pages = client.list_clusters().into_paginator().items().send();
+    while let Some(cluster_arn) = cluster_pages.next().await {
+        cluster_arns.push(cluster_arn?);
     }
 
     let mut tasks: Vec<EcsTaskInfo> = Vec::new();
 
     for cluster_arn in cluster_arns {
-        // Collect RUNNING task ARNs for this cluster, following pagination.
+        // Collect RUNNING task ARNs for this cluster across all pages.
         let mut task_arns: Vec<String> = Vec::new();
-        let mut next_token: Option<String> = None;
-        loop {
-            let resp = client
-                .list_tasks()
-                .cluster(&cluster_arn)
-                .desired_status(DesiredStatus::Running)
-                .set_next_token(next_token)
-                .send()
-                .await?;
-            task_arns.extend(resp.task_arns.unwrap_or_default());
-            next_token = resp.next_token;
-            if next_token.is_none() {
-                break;
-            }
+        let mut task_pages = client
+            .list_tasks()
+            .cluster(&cluster_arn)
+            .desired_status(DesiredStatus::Running)
+            .into_paginator()
+            .items()
+            .send();
+        while let Some(task_arn) = task_pages.next().await {
+            task_arns.push(task_arn?);
         }
 
         // describe_tasks accepts at most 100 task ARNs per call.

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -102,10 +102,10 @@ fn service_from_group(group: &str) -> String {
 #[derive(Debug, Clone)]
 pub struct EcsTaskInfo {
     region: Region,
-    cluster: String,       // raw cluster ARN, passed to `--cluster`
-    cluster_name: String,  // short name, for display + search
-    task_arn: String,      // raw task ARN, passed to `--task`
-    task_id: String,       // short id, for display + search
+    cluster: String,      // raw cluster ARN, passed to `--cluster`
+    cluster_name: String, // short name, for display + search
+    task_arn: String,     // raw task ARN, passed to `--task`
+    task_id: String,      // short id, for display + search
     task_definition: String,
     service: String,
     last_status: String,
@@ -220,30 +220,31 @@ pub async fn fetch_ecs_tasks(region: Region) -> Result<Vec<EcsTaskInfo>> {
     let client = aws_sdk_ecs::Client::new(&config);
 
     // Enumerate clusters across all pages via the SDK paginator.
-    let mut cluster_arns: Vec<String> = Vec::new();
-    let mut cluster_pages = client.list_clusters().into_paginator().items().send();
-    while let Some(cluster_arn) = cluster_pages.next().await {
-        cluster_arns.push(cluster_arn?);
-    }
+    let cluster_arns: Result<Vec<String>, _> = client
+        .list_clusters()
+        .into_paginator()
+        .items()
+        .send()
+        .collect()
+        .await;
+
+    let cluster_arns = cluster_arns?;
 
     let mut tasks: Vec<EcsTaskInfo> = Vec::new();
 
     for cluster_arn in cluster_arns {
-        // Collect RUNNING task ARNs for this cluster across all pages.
-        let mut task_arns: Vec<String> = Vec::new();
-        let mut task_pages = client
+        let task_arns: Result<Vec<String>, _> = client
             .list_tasks()
             .cluster(&cluster_arn)
             .desired_status(DesiredStatus::Running)
             .into_paginator()
             .items()
-            .send();
-        while let Some(task_arn) = task_pages.next().await {
-            task_arns.push(task_arn?);
-        }
+            .send()
+            .collect()
+            .await;
 
         // describe_tasks accepts at most 100 task ARNs per call.
-        for chunk in task_arns.chunks(100) {
+        for chunk in task_arns?.chunks(100) {
             let described = client
                 .describe_tasks()
                 .cluster(&cluster_arn)
@@ -326,9 +327,15 @@ mod tests {
         assert_eq!(task.get_task_definition(), "web:7");
         assert_eq!(task.get_service(), "web-api");
         assert_eq!(task.get_last_status(), "RUNNING");
-        assert_eq!(task.get_containers(), &["app".to_string(), "sidecar".to_string()]);
+        assert_eq!(
+            task.get_containers(),
+            &["app".to_string(), "sidecar".to_string()]
+        );
         // The raw cluster / task ARNs are preserved for the CLI command.
         assert_eq!(task.get_cluster(), "arn:aws:ecs:us-east-1:123:cluster/prod");
-        assert_eq!(task.get_task_arn(), "arn:aws:ecs:us-east-1:123:task/prod/deadbeef");
+        assert_eq!(
+            task.get_task_arn(),
+            "arn:aws:ecs:us-east-1:123:task/prod/deadbeef"
+        );
     }
 }

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -86,6 +86,92 @@ impl InstanceInfo {
     }
 }
 
+/// Returns the final `/`-delimited segment of an ARN (cluster name, task id, or
+/// `family:revision`). Returns the input unchanged when there is no `/`.
+fn short_name_from_arn(arn: &str) -> String {
+    arn.rsplit('/').next().unwrap_or(arn).to_string()
+}
+
+/// ECS task `group` is `service:<name>` for service-managed tasks. Returns the
+/// service name, or an empty string for standalone tasks.
+fn service_from_group(group: &str) -> String {
+    group.strip_prefix("service:").unwrap_or("").to_string()
+}
+
+#[derive(Debug, Clone)]
+pub struct EcsTaskInfo {
+    region: Region,
+    cluster: String,       // raw cluster ARN, passed to `--cluster`
+    cluster_name: String,  // short name, for display + search
+    task_arn: String,      // raw task ARN, passed to `--task`
+    task_id: String,       // short id, for display + search
+    task_definition: String,
+    service: String,
+    last_status: String,
+    containers: Vec<String>,
+}
+
+impl EcsTaskInfo {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        region: Region,
+        cluster_arn: String,
+        task_arn: String,
+        task_definition_arn: String,
+        group: String,
+        last_status: String,
+        containers: Vec<String>,
+    ) -> Self {
+        EcsTaskInfo {
+            region,
+            cluster_name: short_name_from_arn(&cluster_arn),
+            cluster: cluster_arn,
+            task_id: short_name_from_arn(&task_arn),
+            task_arn,
+            task_definition: short_name_from_arn(&task_definition_arn),
+            service: service_from_group(&group),
+            last_status,
+            containers,
+        }
+    }
+
+    pub fn get_region(&self) -> Region {
+        self.region.clone()
+    }
+
+    pub fn get_cluster(&self) -> &str {
+        &self.cluster
+    }
+
+    pub fn cluster_name(&self) -> &str {
+        &self.cluster_name
+    }
+
+    pub fn get_task_arn(&self) -> &str {
+        &self.task_arn
+    }
+
+    pub fn get_task_id(&self) -> &str {
+        &self.task_id
+    }
+
+    pub fn get_task_definition(&self) -> &str {
+        &self.task_definition
+    }
+
+    pub fn get_service(&self) -> &str {
+        &self.service
+    }
+
+    pub fn get_last_status(&self) -> &str {
+        &self.last_status
+    }
+
+    pub fn get_containers(&self) -> &[String] {
+        &self.containers
+    }
+}
+
 pub async fn fetch_instances(region: Region) -> Result<Vec<InstanceInfo>> {
     let config = aws_config::defaults(BehaviorVersion::latest())
         .region(region.clone())
@@ -119,4 +205,53 @@ pub async fn fetch_instances(region: Region) -> Result<Vec<InstanceInfo>> {
         })
         .collect();
     Ok(instances)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_name_from_arn_takes_last_segment() {
+        assert_eq!(
+            short_name_from_arn("arn:aws:ecs:us-east-1:123:cluster/my-cluster"),
+            "my-cluster"
+        );
+        assert_eq!(
+            short_name_from_arn("arn:aws:ecs:us-east-1:123:task/my-cluster/abc123"),
+            "abc123"
+        );
+        // No slash: returns the input unchanged.
+        assert_eq!(short_name_from_arn("plain"), "plain");
+    }
+
+    #[test]
+    fn service_from_group_strips_service_prefix() {
+        assert_eq!(service_from_group("service:web-api"), "web-api");
+        // Standalone tasks have a non-service group -> empty.
+        assert_eq!(service_from_group("family:batch-job"), "");
+        assert_eq!(service_from_group(""), "");
+    }
+
+    #[test]
+    fn ecs_task_info_new_parses_display_fields() {
+        let task = EcsTaskInfo::new(
+            Region::new("us-east-1"),
+            "arn:aws:ecs:us-east-1:123:cluster/prod".to_string(),
+            "arn:aws:ecs:us-east-1:123:task/prod/deadbeef".to_string(),
+            "arn:aws:ecs:us-east-1:123:task-definition/web:7".to_string(),
+            "service:web-api".to_string(),
+            "RUNNING".to_string(),
+            vec!["app".to_string(), "sidecar".to_string()],
+        );
+        assert_eq!(task.cluster_name(), "prod");
+        assert_eq!(task.get_task_id(), "deadbeef");
+        assert_eq!(task.get_task_definition(), "web:7");
+        assert_eq!(task.get_service(), "web-api");
+        assert_eq!(task.get_last_status(), "RUNNING");
+        assert_eq!(task.get_containers(), &["app".to_string(), "sidecar".to_string()]);
+        // The raw cluster / task ARNs are preserved for the CLI command.
+        assert_eq!(task.get_cluster(), "arn:aws:ecs:us-east-1:123:cluster/prod");
+        assert_eq!(task.get_task_arn(), "arn:aws:ecs:us-east-1:123:task/prod/deadbeef");
+    }
 }

--- a/src/components.rs
+++ b/src/components.rs
@@ -5,6 +5,7 @@ pub mod instance_table;
 pub mod loader;
 pub mod region_list;
 pub mod simple_list;
+pub mod task_table;
 pub mod text_input;
 use anyhow::Result;
 use crossterm::event::Event;

--- a/src/components.rs
+++ b/src/components.rs
@@ -4,6 +4,7 @@ pub mod header_tabs;
 pub mod instance_table;
 pub mod loader;
 pub mod region_list;
+pub mod simple_list;
 pub mod text_input;
 use anyhow::Result;
 use crossterm::event::Event;

--- a/src/components/config_list.rs
+++ b/src/components/config_list.rs
@@ -1,3 +1,4 @@
+use crate::app::config::Config;
 use crate::components::Component;
 use anyhow::Result;
 use crossterm::event::{Event, KeyCode};
@@ -7,36 +8,51 @@ use ratatui::{
     style::{Color, Modifier, Style},
     widgets::{Block, Borders, List, ListItem, ListState, Row, Table},
 };
+use std::sync::{Arc, Mutex};
 
 use super::get_help_styled;
 #[derive(Debug, Clone, Copy)]
 pub enum ConfigOption {
     ResetRecent,
     SetRecentTimeout,
+    ToggleEc2,
+    ToggleEcs,
 }
 
-impl From<ConfigOption> for String {
-    fn from(option: ConfigOption) -> String {
-        match option {
-            ConfigOption::ResetRecent => "Reset Recent Instances".to_string(),
-            ConfigOption::SetRecentTimeout => "Set Recent Timeout".to_string(),
-        }
-    }
-}
-
-const CONFIG_OPTIONS: [ConfigOption; 2] =
-    [ConfigOption::ResetRecent, ConfigOption::SetRecentTimeout];
+const CONFIG_OPTIONS: [ConfigOption; 4] = [
+    ConfigOption::ResetRecent,
+    ConfigOption::SetRecentTimeout,
+    ConfigOption::ToggleEc2,
+    ConfigOption::ToggleEcs,
+];
 
 #[derive(Debug)]
 pub struct ConfigList {
     state: ListState,
+    config: Arc<Mutex<Config>>,
 }
 
 impl ConfigList {
-    pub fn new() -> ConfigList {
+    pub fn new(config: Arc<Mutex<Config>>) -> ConfigList {
         let mut state = ListState::default();
         state.select(Some(0));
-        ConfigList { state }
+        ConfigList { state, config }
+    }
+
+    /// Display label for an option. The mode toggles show their current state.
+    fn label(&self, option: ConfigOption) -> String {
+        match option {
+            ConfigOption::ResetRecent => "Reset Recent Instances".to_string(),
+            ConfigOption::SetRecentTimeout => "Set Recent Timeout".to_string(),
+            ConfigOption::ToggleEc2 => {
+                let enabled = self.config.lock().unwrap().is_ec2_enabled();
+                format!("EC2 mode: {}", if enabled { "enabled" } else { "disabled" })
+            }
+            ConfigOption::ToggleEcs => {
+                let enabled = self.config.lock().unwrap().is_ecs_enabled();
+                format!("ECS mode: {}", if enabled { "enabled" } else { "disabled" })
+            }
+        }
     }
 
     fn next(&mut self) {
@@ -75,7 +91,7 @@ impl ConfigList {
         let items: Vec<ListItem> = CONFIG_OPTIONS
             .iter()
             .map(|i| {
-                let name: String = (*i).into();
+                let name = self.label(*i);
                 ListItem::new(name)
             })
             .collect();

--- a/src/components/header_tabs.rs
+++ b/src/components/header_tabs.rs
@@ -9,13 +9,17 @@ use ratatui::{
 use super::Component;
 
 pub struct HeaderTabs {
+    tabs: Vec<Tab>,
     selected: Option<Tab>,
 }
-#[derive(Debug, Clone, Copy)]
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Tab {
     Region,
     Instances,
     Connection,
+    Tasks,
+    Container,
 }
 
 impl Tab {
@@ -24,15 +28,19 @@ impl Tab {
             Tab::Region => "Region",
             Tab::Instances => "Instances",
             Tab::Connection => "Connection",
+            Tab::Tasks => "Tasks",
+            Tab::Container => "Container",
         }
     }
 
-    pub fn get_index(&self) -> usize {
-        match self {
-            Tab::Region => 0,
-            Tab::Instances => 1,
-            Tab::Connection => 2,
-        }
+    /// The EC2 / Session Manager flow steps.
+    pub fn ec2_flow() -> Vec<Tab> {
+        vec![Tab::Region, Tab::Instances, Tab::Connection]
+    }
+
+    /// The ECS Exec flow steps.
+    pub fn ecs_flow() -> Vec<Tab> {
+        vec![Tab::Region, Tab::Tasks, Tab::Container]
     }
 }
 
@@ -43,16 +51,15 @@ impl From<Tab> for Line<'static> {
 }
 
 impl HeaderTabs {
-    pub fn new() -> Self {
-        Self { selected: None }
+    pub fn new(tabs: Vec<Tab>) -> Self {
+        Self {
+            tabs,
+            selected: None,
+        }
     }
 
     pub fn set_selected(&mut self, tab: Tab) {
         self.selected = Some(tab);
-    }
-
-    pub fn get_all_tabs(&self) -> Vec<Tab> {
-        vec![Tab::Region, Tab::Instances, Tab::Connection]
     }
 }
 
@@ -70,11 +77,14 @@ impl Component for HeaderTabs {
     }
 
     fn view(&mut self, frame: &mut Frame, area: Rect) {
-        let tabs = Tabs::new(self.get_all_tabs())
+        let selected_index = self
+            .selected
+            .and_then(|sel| self.tabs.iter().position(|t| *t == sel));
+        let tabs = Tabs::new(self.tabs.clone())
             .block(Block::bordered())
             .style(Style::default().white())
             .highlight_style(Style::default().yellow())
-            .select(self.selected.map(|tab| tab.get_index()));
+            .select(selected_index);
         frame.render_widget(tabs, area);
     }
 

--- a/src/components/simple_list.rs
+++ b/src/components/simple_list.rs
@@ -1,0 +1,163 @@
+use crossterm::event::{Event, KeyCode};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    widgets::{Block, Borders, List, ListItem, ListState, Row, Table},
+};
+
+use super::{Component, get_help_styled};
+use anyhow::Result;
+
+#[derive(Debug, Clone)]
+pub struct SimpleList {
+    state: ListState,
+    items: Vec<String>,
+}
+
+impl SimpleList {
+    pub fn new(items: Vec<String>) -> SimpleList {
+        let mut state = ListState::default();
+        if !items.is_empty() {
+            state.select(Some(0));
+        }
+        SimpleList { state, items }
+    }
+
+    fn next(&mut self) {
+        if self.items.is_empty() {
+            return;
+        }
+        let i = match self.state.selected() {
+            Some(i) if i >= self.items.len() - 1 => 0,
+            Some(i) => i + 1,
+            None => 0,
+        };
+        self.state.select(Some(i));
+    }
+
+    fn previous(&mut self) {
+        if self.items.is_empty() {
+            return;
+        }
+        let i = match self.state.selected() {
+            Some(0) | None => self.items.len() - 1,
+            Some(i) => i - 1,
+        };
+        self.state.select(Some(i));
+    }
+
+    fn current(&self) -> Option<String> {
+        self.state.selected().map(|i| self.items[i].clone())
+    }
+
+    fn get_list(&self) -> List<'_> {
+        let items: Vec<ListItem> = self
+            .items
+            .iter()
+            .map(|i| ListItem::new(i.clone()))
+            .collect();
+        List::new(items)
+            .block(Block::default().borders(Borders::ALL))
+            .highlight_style(
+                Style::default()
+                    .bg(Color::LightGreen)
+                    .fg(Color::Black)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .highlight_symbol(">> ")
+    }
+
+    fn get_help(&self) -> Table<'_> {
+        let rows = vec![Row::new(vec![get_help_styled('q', "Exit")])];
+        Table::new(rows, vec![Constraint::Min(10)])
+    }
+}
+
+pub enum SimpleListMessage {
+    Exit,
+    Up,
+    Down,
+    Enter,
+}
+
+pub enum SimpleListOutputAction {
+    Exit,
+    Return(String),
+}
+
+impl Component for SimpleList {
+    type Message = SimpleListMessage;
+    type OutputAction = SimpleListOutputAction;
+
+    fn update(&mut self, msg: Option<SimpleListMessage>) -> Result<Option<Self::OutputAction>> {
+        match msg {
+            Some(SimpleListMessage::Exit) => Ok(Some(SimpleListOutputAction::Exit)),
+            Some(SimpleListMessage::Up) => {
+                self.previous();
+                Ok(None)
+            }
+            Some(SimpleListMessage::Down) => {
+                self.next();
+                Ok(None)
+            }
+            Some(SimpleListMessage::Enter) => match self.current() {
+                Some(item) => Ok(Some(SimpleListOutputAction::Return(item))),
+                None => Ok(None),
+            },
+            None => Ok(None),
+        }
+    }
+
+    fn view(&mut self, frame: &mut Frame, area: Rect) {
+        let vertical_layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(vec![Constraint::Fill(1), Constraint::Max(1)])
+            .split(area);
+        let list = self.get_list();
+        frame.render_stateful_widget(list, vertical_layout[0], &mut self.state.clone());
+        let help = self.get_help();
+        frame.render_widget(help, vertical_layout[1]);
+    }
+
+    fn handle_event(&self, event: Event) -> Option<Self::Message> {
+        match event {
+            Event::Key(key) => match key.code {
+                KeyCode::Char('q') => Some(SimpleListMessage::Exit),
+                KeyCode::Down => Some(SimpleListMessage::Down),
+                KeyCode::Up => Some(SimpleListMessage::Up),
+                KeyCode::Right | KeyCode::Enter => Some(SimpleListMessage::Enter),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_wraps_around() {
+        let mut list = SimpleList::new(vec!["a".into(), "b".into()]);
+        assert_eq!(list.current(), Some("a".to_string()));
+        list.next();
+        assert_eq!(list.current(), Some("b".to_string()));
+        list.next(); // wraps to start
+        assert_eq!(list.current(), Some("a".to_string()));
+    }
+
+    #[test]
+    fn previous_wraps_around() {
+        let mut list = SimpleList::new(vec!["a".into(), "b".into()]);
+        list.previous(); // wraps to end
+        assert_eq!(list.current(), Some("b".to_string()));
+    }
+
+    #[test]
+    fn empty_list_has_no_current() {
+        let list = SimpleList::new(vec![]);
+        assert_eq!(list.current(), None);
+    }
+}

--- a/src/components/simple_list.rs
+++ b/src/components/simple_list.rs
@@ -55,7 +55,7 @@ impl SimpleList {
         let items: Vec<ListItem> = self
             .items
             .iter()
-            .map(|i| ListItem::new(i.clone()))
+            .map(|i| ListItem::new(i.as_str()))
             .collect();
         List::new(items)
             .block(Block::default().borders(Borders::ALL))

--- a/src/components/task_table.rs
+++ b/src/components/task_table.rs
@@ -157,6 +157,9 @@ pub enum TaskTableMessage {
     Search,
 }
 
+// Short-lived outcome enum built and matched immediately, so the size spread
+// between the data and unit variants does not matter (mirrors the EC2 outcome enums).
+#[allow(clippy::large_enum_variant)]
 pub enum TaskTableOutputAction {
     Exit,
     ReturnTask(EcsTaskInfo),

--- a/src/components/task_table.rs
+++ b/src/components/task_table.rs
@@ -1,0 +1,252 @@
+use crate::aws::EcsTaskInfo;
+use crossterm::event::{Event, KeyCode};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    widgets::{Block, Borders, Cell, Row, Table, TableState},
+};
+
+use super::{Component, get_help_styled};
+use anyhow::Result;
+
+#[derive(Debug, Clone)]
+pub struct TaskTable {
+    pub state: TableState,
+    items: Vec<EcsTaskInfo>,
+    visible_items: Vec<EcsTaskInfo>,
+    filter: String,
+}
+
+impl TaskTable {
+    pub fn new() -> TaskTable {
+        TaskTable {
+            state: TableState::default(),
+            items: vec![],
+            visible_items: vec![],
+            filter: String::default(),
+        }
+    }
+
+    pub fn set_tasks(&mut self, tasks: Vec<EcsTaskInfo>) {
+        self.items = tasks;
+        self.apply_filter(self.filter.clone());
+    }
+
+    /// Case-insensitive substring match across cluster, task id, definition,
+    /// service, and status.
+    pub fn apply_filter(&mut self, filter: String) {
+        self.filter = filter;
+        let needle = self.filter.to_lowercase();
+        self.visible_items = self
+            .items
+            .iter()
+            .filter(|t| {
+                let haystack = format!(
+                    "{} {} {} {} {}",
+                    t.get_cluster_name(),
+                    t.get_task_id(),
+                    t.get_task_definition(),
+                    t.get_service(),
+                    t.get_last_status(),
+                )
+                .to_lowercase();
+                haystack.contains(&needle)
+            })
+            .cloned()
+            .collect();
+        self.state.select(if self.visible_items.is_empty() {
+            None
+        } else {
+            Some(0)
+        });
+    }
+
+    #[cfg(test)]
+    pub fn visible_len(&self) -> usize {
+        self.visible_items.len()
+    }
+
+    pub fn next(&mut self) {
+        if self.visible_items.is_empty() {
+            return;
+        }
+        let i = match self.state.selected() {
+            Some(i) if i >= self.visible_items.len() - 1 => 0,
+            Some(i) => i + 1,
+            None => 0,
+        };
+        self.state.select(Some(i));
+    }
+
+    pub fn previous(&mut self) {
+        if self.visible_items.is_empty() {
+            return;
+        }
+        let i = match self.state.selected() {
+            Some(0) | None => self.visible_items.len() - 1,
+            Some(i) => i - 1,
+        };
+        self.state.select(Some(i));
+    }
+
+    pub fn current(&self) -> Option<EcsTaskInfo> {
+        self.state.selected().map(|i| self.visible_items[i].clone())
+    }
+
+    fn get_table(&self) -> Table<'_> {
+        let items: Vec<Row> = self
+            .visible_items
+            .iter()
+            .map(|t| {
+                Row::new(vec![
+                    Cell::from(t.get_cluster_name().to_string()),
+                    Cell::from(t.get_task_id().to_string()),
+                    Cell::from(t.get_task_definition().to_string()),
+                    Cell::from(t.get_service().to_string()),
+                    Cell::from(t.get_last_status().to_string()),
+                    Cell::from(t.get_containers().len().to_string()),
+                ])
+                .height(1)
+            })
+            .collect();
+        let widths = [
+            Constraint::Percentage(18),
+            Constraint::Percentage(22),
+            Constraint::Percentage(22),
+            Constraint::Percentage(20),
+            Constraint::Percentage(10),
+            Constraint::Percentage(8),
+        ];
+        Table::new(items, widths)
+            .block(Block::default().borders(Borders::ALL))
+            .row_highlight_style(
+                Style::default()
+                    .bg(Color::LightGreen)
+                    .fg(Color::Black)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .highlight_symbol(">> ")
+            .header(
+                Row::new(vec![
+                    "Cluster",
+                    "Task ID",
+                    "Task Definition",
+                    "Service",
+                    "Status",
+                    "Containers",
+                ])
+                .style(Style::default().add_modifier(Modifier::BOLD).underlined()),
+            )
+    }
+
+    fn get_help(&self) -> Table<'_> {
+        let rows = vec![Row::new(vec![
+            get_help_styled('q', "Exit"),
+            get_help_styled('/', "Search"),
+        ])];
+        Table::new(rows, vec![Constraint::Min(10), Constraint::Min(10)])
+    }
+}
+
+pub enum TaskTableMessage {
+    Exit,
+    Up,
+    Down,
+    Enter,
+    Search,
+}
+
+pub enum TaskTableOutputAction {
+    Exit,
+    ReturnTask(EcsTaskInfo),
+    Search,
+}
+
+impl Component for TaskTable {
+    type Message = TaskTableMessage;
+    type OutputAction = TaskTableOutputAction;
+
+    fn update(&mut self, msg: Option<TaskTableMessage>) -> Result<Option<Self::OutputAction>> {
+        let Some(msg) = msg else {
+            return Ok(None);
+        };
+        match msg {
+            TaskTableMessage::Exit => Ok(Some(TaskTableOutputAction::Exit)),
+            TaskTableMessage::Up => {
+                self.previous();
+                Ok(None)
+            }
+            TaskTableMessage::Down => {
+                self.next();
+                Ok(None)
+            }
+            TaskTableMessage::Enter => match self.current() {
+                Some(task) => Ok(Some(TaskTableOutputAction::ReturnTask(task))),
+                None => Ok(None),
+            },
+            TaskTableMessage::Search => Ok(Some(TaskTableOutputAction::Search)),
+        }
+    }
+
+    fn view(&mut self, frame: &mut Frame, area: Rect) {
+        let vertical_layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(vec![Constraint::Fill(1), Constraint::Max(1)])
+            .split(area);
+        let widget = self.get_table();
+        frame.render_stateful_widget(widget, vertical_layout[0], &mut self.state.clone());
+        let help = self.get_help();
+        frame.render_widget(help, vertical_layout[1]);
+    }
+
+    fn handle_event(&self, event: Event) -> Option<Self::Message> {
+        match event {
+            Event::Key(key) => match key.code {
+                KeyCode::Char('q') => Some(TaskTableMessage::Exit),
+                KeyCode::Down => Some(TaskTableMessage::Down),
+                KeyCode::Up => Some(TaskTableMessage::Up),
+                KeyCode::Right | KeyCode::Enter => Some(TaskTableMessage::Enter),
+                KeyCode::Char('/') => Some(TaskTableMessage::Search),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::aws::EcsTaskInfo;
+    use aws_config::Region;
+
+    fn sample(service: &str) -> EcsTaskInfo {
+        EcsTaskInfo::new(
+            Region::new("us-east-1"),
+            "arn:aws:ecs:us-east-1:123:cluster/prod".to_string(),
+            format!("arn:aws:ecs:us-east-1:123:task/prod/{}", service),
+            "arn:aws:ecs:us-east-1:123:task-definition/def:1".to_string(),
+            format!("service:{}", service),
+            "RUNNING".to_string(),
+            vec!["app".to_string()],
+        )
+    }
+
+    #[test]
+    fn apply_filter_matches_service_substring() {
+        let mut table = TaskTable::new();
+        table.set_tasks(vec![sample("web-api"), sample("worker")]);
+        table.apply_filter("web".to_string());
+        assert_eq!(table.visible_len(), 1);
+        assert_eq!(table.current().unwrap().get_service(), "web-api");
+    }
+
+    #[test]
+    fn empty_filter_shows_all() {
+        let mut table = TaskTable::new();
+        table.set_tasks(vec![sample("web-api"), sample("worker")]);
+        table.apply_filter(String::new());
+        assert_eq!(table.visible_len(), 2);
+    }
+}

--- a/src/components/task_table.rs
+++ b/src/components/task_table.rs
@@ -221,11 +221,13 @@ mod tests {
     use crate::aws::EcsTaskInfo;
     use aws_config::Region;
 
+    // Task id is a fixed, neutral value so a filter on the service name can only
+    // match via the service field (not incidentally via the task id).
     fn sample(service: &str) -> EcsTaskInfo {
         EcsTaskInfo::new(
             Region::new("us-east-1"),
             "arn:aws:ecs:us-east-1:123:cluster/prod".to_string(),
-            format!("arn:aws:ecs:us-east-1:123:task/prod/{}", service),
+            "arn:aws:ecs:us-east-1:123:task/prod/0123456789ab".to_string(),
             "arn:aws:ecs:us-east-1:123:task-definition/def:1".to_string(),
             format!("service:{}", service),
             "RUNNING".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,7 @@ async fn main() -> Result<()> {
         Ok(Some(UserAction::Connect(instance))) => connect(instance)?,
         Ok(Some(UserAction::Tunnel(instance))) => tunnel(instance)?,
         Ok(Some(UserAction::FileManager(instance))) => launch_file_manager(instance)?,
+        Ok(Some(UserAction::EcsExec { task, container })) => ecs_exec(task, container)?,
         Ok(None) => {}
     }
     Ok(())
@@ -121,6 +122,24 @@ fn tunnel(instance: InstanceInfo) -> Result<()> {
 fn launch_file_manager(instance: InstanceInfo) -> Result<()> {
     let mut app = FileManagerApp::new()?;
     app.run(instance)
+}
+
+fn ecs_exec(task: aws::EcsTaskInfo, container: String) -> Result<()> {
+    run_aws_command(&[
+        "--region",
+        task.get_region().as_ref(),
+        "ecs",
+        "execute-command",
+        "--cluster",
+        task.get_cluster(),
+        "--task",
+        task.get_task_arn(),
+        "--container",
+        &container,
+        "--interactive",
+        "--command",
+        "/bin/sh",
+    ])
 }
 
 fn connect(instance: InstanceInfo) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,6 +138,7 @@ fn ecs_exec(task: aws::EcsTaskInfo, container: String) -> Result<()> {
         &container,
         "--interactive",
         "--command",
+        // v1: shell is hardcoded; making this configurable is a deliberate future step.
         "/bin/sh",
     ])
 }

--- a/src/screens.rs
+++ b/src/screens.rs
@@ -6,6 +6,7 @@ pub mod instance_select_screen;
 pub mod loading_instances_screen;
 pub mod loading_tasks_screen;
 pub mod region_select_screen;
+pub mod task_select_screen;
 pub mod username_prompt_screen;
 
 use std::io::Stdout;

--- a/src/screens.rs
+++ b/src/screens.rs
@@ -4,6 +4,7 @@ pub mod file_manager_screen;
 pub mod connecting_screen;
 pub mod instance_select_screen;
 pub mod loading_instances_screen;
+pub mod loading_tasks_screen;
 pub mod region_select_screen;
 pub mod username_prompt_screen;
 

--- a/src/screens.rs
+++ b/src/screens.rs
@@ -1,4 +1,5 @@
 pub mod config_screen;
+pub mod mode_select_screen;
 pub mod file_manager_screen;
 pub mod connecting_screen;
 pub mod instance_select_screen;

--- a/src/screens.rs
+++ b/src/screens.rs
@@ -8,6 +8,7 @@ pub mod loading_tasks_screen;
 pub mod region_select_screen;
 pub mod task_select_screen;
 pub mod username_prompt_screen;
+pub mod container_select_screen;
 
 use std::io::Stdout;
 

--- a/src/screens/config_screen.rs
+++ b/src/screens/config_screen.rs
@@ -31,7 +31,14 @@ pub struct ConfigScreen {
     input_component: TextInput,
     input_active: bool,
     modifying_action: Option<ConfigOption>,
-    last_operation_success: Option<bool>,
+    feedback: OperationFeedback,
+}
+
+/// Banner state shown at the bottom of the config screen.
+enum OperationFeedback {
+    None,
+    Success,
+    Failure(String),
 }
 
 pub enum ConfigScreenOutcome {
@@ -48,7 +55,7 @@ impl ConfigScreen {
             input_component,
             input_active: false,
             modifying_action: None,
-            last_operation_success: None,
+            feedback: OperationFeedback::None,
         }
     }
 
@@ -69,8 +76,8 @@ impl ConfigScreen {
                 self.input_component.view(frame, overlay_layout[1]);
             }
 
-            match self.last_operation_success {
-                Some(true) => {
+            match &self.feedback {
+                OperationFeedback::Success => {
                     let line = Paragraph::new(Text::from("Operation successful"))
                         .centered()
                         .bg(Color::Green)
@@ -78,15 +85,15 @@ impl ConfigScreen {
                     frame.render_widget(Clear, overlay_layout[1]);
                     frame.render_widget(line, overlay_layout[1]);
                 }
-                Some(false) => {
-                    let line = Paragraph::new(Text::from("Operation failed"))
+                OperationFeedback::Failure(message) => {
+                    let line = Paragraph::new(Text::from(message.clone()))
                         .centered()
                         .bg(Color::Red)
                         .block(Block::default().borders(Borders::ALL));
                     frame.render_widget(Clear, overlay_layout[1]);
                     frame.render_widget(line, overlay_layout[1]);
                 }
-                None => {}
+                OperationFeedback::None => {}
             }
         })?;
         Ok(())
@@ -103,11 +110,19 @@ impl Screen for ConfigScreen {
                 let message = self.config_list.handle_event(event);
                 let action = self.config_list.update(message)?;
                 match action {
-                    Some(ConfigListOutputAction::Exit) => return Ok(Self::Outcome::Exit),
+                    Some(ConfigListOutputAction::Exit) => {
+                        // Persist on exit. The persist gate rejects a both-modes-off
+                        // state, so leaving is blocked (banner shown) until the user
+                        // re-enables a mode. Any IO error surfaces the same way.
+                        match self.config.lock().unwrap().persist() {
+                            Ok(()) => return Ok(Self::Outcome::Exit),
+                            Err(e) => self.feedback = OperationFeedback::Failure(e.to_string()),
+                        }
+                    }
                     Some(ConfigListOutputAction::ReturnConfig(option)) => match option {
                         ConfigOption::ResetRecent => {
                             History::reset().context("Failed to reset history")?;
-                            self.last_operation_success = Some(true);
+                            self.feedback = OperationFeedback::Success;
                         }
                         ConfigOption::SetRecentTimeout => {
                             self.modifying_action = Some(ConfigOption::SetRecentTimeout);
@@ -116,23 +131,18 @@ impl Screen for ConfigScreen {
                             self.input_component.set_value(current_value.to_string());
                         }
                         ConfigOption::ToggleEc2 => {
-                            // Success is silent (the list label flips); a refused
-                            // toggle (would disable the last mode) shows the failure banner.
-                            match self.config.lock().unwrap().toggle_ec2() {
-                                Ok(()) => self.last_operation_success = None,
-                                Err(_) => self.last_operation_success = Some(false),
-                            }
+                            // Toggling can't fail; both modes may be off transiently
+                            // (enforced on exit). Clear any stale banner.
+                            self.config.lock().unwrap().toggle_ec2();
+                            self.feedback = OperationFeedback::None;
                         }
                         ConfigOption::ToggleEcs => {
-                            // Same silent-success / banner-on-refusal handling as ToggleEc2.
-                            match self.config.lock().unwrap().toggle_ecs() {
-                                Ok(()) => self.last_operation_success = None,
-                                Err(_) => self.last_operation_success = Some(false),
-                            }
+                            self.config.lock().unwrap().toggle_ecs();
+                            self.feedback = OperationFeedback::None;
                         }
                     },
                     None => {
-                        self.last_operation_success = None;
+                        self.feedback = OperationFeedback::None;
                     }
                 }
             } else {
@@ -145,10 +155,12 @@ impl Screen for ConfigScreen {
                     Some(TextInputOutputAction::Return(search)) => {
                         if let Some(ConfigOption::SetRecentTimeout) = self.modifying_action {
                             if let Ok(timeout) = search.parse::<u64>() {
-                                self.config.lock().unwrap().set_recent_timeout(timeout)?;
-                                self.last_operation_success = Some(true);
+                                self.config.lock().unwrap().set_recent_timeout(timeout);
+                                self.feedback = OperationFeedback::Success;
                             } else {
-                                self.last_operation_success = Some(false);
+                                self.feedback = OperationFeedback::Failure(
+                                    "Timeout must be a whole number of seconds".to_string(),
+                                );
                             }
                         }
                         self.input_active = false;

--- a/src/screens/config_screen.rs
+++ b/src/screens/config_screen.rs
@@ -40,7 +40,7 @@ pub enum ConfigScreenOutcome {
 
 impl ConfigScreen {
     pub fn new(config: Arc<Mutex<Config>>) -> Self {
-        let config_list = ConfigList::new();
+        let config_list = ConfigList::new(config.clone());
         let input_component = TextInput::new("Value: ".to_string());
         Self {
             config,
@@ -114,6 +114,20 @@ impl Screen for ConfigScreen {
                             self.input_active = true;
                             let current_value = self.config.lock().unwrap().get_recent_timeout();
                             self.input_component.set_value(current_value.to_string());
+                        }
+                        ConfigOption::ToggleEc2 => {
+                            // Success is silent (the list label flips); a refused
+                            // toggle (would disable the last mode) shows the failure banner.
+                            match self.config.lock().unwrap().toggle_ec2() {
+                                Ok(()) => self.last_operation_success = None,
+                                Err(_) => self.last_operation_success = Some(false),
+                            }
+                        }
+                        ConfigOption::ToggleEcs => {
+                            match self.config.lock().unwrap().toggle_ecs() {
+                                Ok(()) => self.last_operation_success = None,
+                                Err(_) => self.last_operation_success = Some(false),
+                            }
                         }
                     },
                     None => {

--- a/src/screens/config_screen.rs
+++ b/src/screens/config_screen.rs
@@ -124,6 +124,7 @@ impl Screen for ConfigScreen {
                             }
                         }
                         ConfigOption::ToggleEcs => {
+                            // Same silent-success / banner-on-refusal handling as ToggleEc2.
                             match self.config.lock().unwrap().toggle_ecs() {
                                 Ok(()) => self.last_operation_success = None,
                                 Err(_) => self.last_operation_success = Some(false),

--- a/src/screens/container_select_screen.rs
+++ b/src/screens/container_select_screen.rs
@@ -1,0 +1,69 @@
+use std::io::Stdout;
+
+use crossterm::event;
+use ratatui::{
+    Terminal,
+    layout::{Constraint, Direction, Layout},
+    prelude::CrosstermBackend,
+};
+
+use crate::components::{
+    Component,
+    header_tabs::{HeaderTabs, Tab},
+    simple_list::{SimpleList, SimpleListOutputAction},
+};
+
+use super::Screen;
+use anyhow::Result;
+
+pub struct ContainerSelectScreen {
+    header_tabs_component: HeaderTabs,
+    list: SimpleList,
+}
+
+pub enum ContainerSelectScreenOutcome {
+    Exit,
+    Return(String),
+}
+
+impl ContainerSelectScreen {
+    pub fn new(containers: Vec<String>) -> Self {
+        let mut header_tabs_component = HeaderTabs::new(Tab::ecs_flow());
+        header_tabs_component.set_selected(Tab::Container);
+        let list = SimpleList::new(containers);
+        Self {
+            header_tabs_component,
+            list,
+        }
+    }
+}
+
+impl Screen for ContainerSelectScreen {
+    type Outcome = ContainerSelectScreenOutcome;
+    fn run(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    ) -> Result<ContainerSelectScreenOutcome> {
+        loop {
+            terminal.draw(|frame| {
+                let layout = Layout::default()
+                    .direction(Direction::Vertical)
+                    .margin(0)
+                    .constraints([Constraint::Max(3), Constraint::Fill(1)].as_ref())
+                    .split(frame.area());
+                self.header_tabs_component.view(frame, layout[0]);
+                self.list.view(frame, layout[1]);
+            })?;
+            let message = self.list.handle_event(event::read()?);
+            match self.list.update(message)? {
+                Some(SimpleListOutputAction::Exit) => {
+                    return Ok(ContainerSelectScreenOutcome::Exit);
+                }
+                Some(SimpleListOutputAction::Return(container)) => {
+                    return Ok(ContainerSelectScreenOutcome::Return(container));
+                }
+                None => {}
+            }
+        }
+    }
+}

--- a/src/screens/instance_select_screen.rs
+++ b/src/screens/instance_select_screen.rs
@@ -39,7 +39,7 @@ impl InstanceSelectScreen {
     pub fn new() -> InstanceSelectScreen {
         let instance_table_component = InstanceTable::new();
         let search_component = TextInput::default();
-        let mut header_tabs_component = HeaderTabs::new();
+        let mut header_tabs_component = HeaderTabs::new(Tab::ec2_flow());
         header_tabs_component.set_selected(Tab::Instances);
         Self {
             header_tabs_component,

--- a/src/screens/loading_tasks_screen.rs
+++ b/src/screens/loading_tasks_screen.rs
@@ -1,0 +1,70 @@
+use std::{io::Stdout, time::Duration};
+
+use anyhow::{Context, Result};
+use crossterm::event;
+use ratatui::{Terminal, prelude::CrosstermBackend};
+use tokio::sync::oneshot;
+
+use crate::{
+    aws::EcsTaskInfo,
+    components::{
+        Component,
+        loader::{Loader, LoaderOutputAction},
+    },
+};
+
+use super::Screen;
+
+type FetchResult = Result<Vec<EcsTaskInfo>>;
+
+pub struct LoadingTasksScreen {
+    loader: Loader<FetchResult>,
+}
+
+pub enum LoadingTasksScreenOutcome {
+    Cancelled,
+    TasksFetched(Vec<EcsTaskInfo>),
+}
+
+impl LoadingTasksScreen {
+    pub fn new(region: String) -> Self {
+        let (tx, rx) = oneshot::channel();
+        let message = format!("Loading ECS tasks for region {}", region);
+        tokio::spawn(async move {
+            let _ = tx.send(crate::aws::fetch_ecs_tasks(aws_config::Region::new(region)).await);
+        });
+        Self {
+            loader: Loader::new(message, rx),
+        }
+    }
+}
+
+impl Screen for LoadingTasksScreen {
+    type Outcome = LoadingTasksScreenOutcome;
+    fn run(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    ) -> Result<LoadingTasksScreenOutcome> {
+        loop {
+            terminal.draw(|frame| self.loader.view(frame, frame.area()))?;
+            let message = if event::poll(Duration::from_millis(50))? {
+                self.loader.handle_event(event::read()?)
+            } else {
+                None
+            };
+            let action = self
+                .loader
+                .update(message)
+                .context("Unexpected error while fetching ECS tasks")?;
+            match action {
+                Some(LoaderOutputAction::Exit) => return Ok(LoadingTasksScreenOutcome::Cancelled),
+                Some(LoaderOutputAction::Return(data)) => {
+                    return Ok(LoadingTasksScreenOutcome::TasksFetched(
+                        data.context("Failed to fetch ECS tasks. Check your AWS credentials.")?,
+                    ));
+                }
+                None => {}
+            }
+        }
+    }
+}

--- a/src/screens/mode_select_screen.rs
+++ b/src/screens/mode_select_screen.rs
@@ -1,0 +1,74 @@
+use std::io::Stdout;
+
+use crossterm::event;
+use ratatui::{
+    Terminal,
+    layout::{Constraint, Direction, Layout},
+    prelude::CrosstermBackend,
+};
+
+use crate::components::{
+    Component,
+    header_tabs::{HeaderTabs, Tab},
+    simple_list::{SimpleList, SimpleListOutputAction},
+};
+
+use super::Screen;
+use anyhow::Result;
+
+const MODE_EC2: &str = "EC2 (Session Manager)";
+const MODE_ECS: &str = "ECS (Exec)";
+
+pub struct ModeSelectScreen {
+    header_tabs_component: HeaderTabs,
+    list: SimpleList,
+}
+
+pub enum ModeSelectScreenOutcome {
+    Exit,
+    Ec2,
+    Ecs,
+}
+
+impl ModeSelectScreen {
+    pub fn new() -> Self {
+        let header_tabs_component = HeaderTabs::new(Tab::ec2_flow());
+        let list = SimpleList::new(vec![MODE_EC2.to_string(), MODE_ECS.to_string()]);
+        Self {
+            header_tabs_component,
+            list,
+        }
+    }
+}
+
+impl Screen for ModeSelectScreen {
+    type Outcome = ModeSelectScreenOutcome;
+    fn run(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    ) -> Result<ModeSelectScreenOutcome> {
+        loop {
+            terminal.draw(|frame| {
+                let layout = Layout::default()
+                    .direction(Direction::Vertical)
+                    .margin(0)
+                    .constraints([Constraint::Max(3), Constraint::Fill(1)].as_ref())
+                    .split(frame.area());
+                self.header_tabs_component.view(frame, layout[0]);
+                self.list.view(frame, layout[1]);
+            })?;
+            let message = self.list.handle_event(event::read()?);
+            match self.list.update(message)? {
+                Some(SimpleListOutputAction::Exit) => return Ok(ModeSelectScreenOutcome::Exit),
+                Some(SimpleListOutputAction::Return(choice)) => {
+                    if choice == MODE_ECS {
+                        return Ok(ModeSelectScreenOutcome::Ecs);
+                    } else {
+                        return Ok(ModeSelectScreenOutcome::Ec2);
+                    }
+                }
+                None => {}
+            }
+        }
+    }
+}

--- a/src/screens/mode_select_screen.rs
+++ b/src/screens/mode_select_screen.rs
@@ -32,6 +32,8 @@ pub enum ModeSelectScreenOutcome {
 
 impl ModeSelectScreen {
     pub fn new() -> Self {
+        // The mode picker sits before the flow branches, so no flow step is
+        // highlighted yet — intentionally no `set_selected` call here.
         let header_tabs_component = HeaderTabs::new(Tab::ec2_flow());
         let list = SimpleList::new(vec![MODE_EC2.to_string(), MODE_ECS.to_string()]);
         Self {

--- a/src/screens/region_select_screen.rs
+++ b/src/screens/region_select_screen.rs
@@ -38,7 +38,7 @@ pub enum RegionSelectScreenOutcome {
 impl RegionSelectScreen {
     pub fn new(config: Arc<Mutex<Config>>) -> Self {
         let region_select_component = RegionList::new(config.clone());
-        let mut header_tabs_component = HeaderTabs::new();
+        let mut header_tabs_component = HeaderTabs::new(Tab::ec2_flow());
         header_tabs_component.set_selected(Tab::Region);
         Self {
             header_tabs_component,

--- a/src/screens/task_select_screen.rs
+++ b/src/screens/task_select_screen.rs
@@ -65,10 +65,12 @@ impl TaskSelectScreen {
                     .direction(ratatui::layout::Direction::Vertical)
                     .constraints(vec![Constraint::Fill(1), Constraint::Max(3)])
                     .split(layout[1]);
-                frame.render_widget(Clear, search_layout[1]);
+                frame.render_widget(Clear, search_layout[1]); //this clears out the background
+                //TODO: Since we are drawing on top, maybe give it some distinct style?
                 self.search_component.view(frame, search_layout[1]);
             }
         })?;
+
         Ok(())
     }
 }
@@ -100,6 +102,8 @@ impl Screen for TaskSelectScreen {
                 let action = self.search_component.update(message)?;
                 match action {
                     Some(TextInputOutputAction::Exit) => {
+                        // Search text is intentionally kept so reopening (`/`) resumes
+                        // the previous query; matches instance_select_screen behavior.
                         self.search_active = false;
                     }
                     Some(TextInputOutputAction::Return(search)) => {

--- a/src/screens/task_select_screen.rs
+++ b/src/screens/task_select_screen.rs
@@ -1,0 +1,125 @@
+use std::io::Stdout;
+
+use crossterm::event;
+use ratatui::{
+    Terminal,
+    layout::{Constraint, Layout},
+    prelude::CrosstermBackend,
+    widgets::Clear,
+};
+
+use crate::{
+    aws::EcsTaskInfo,
+    components::{
+        Component,
+        header_tabs::{HeaderTabs, Tab},
+        task_table::{TaskTable, TaskTableOutputAction},
+        text_input::{TextInput, TextInputOutputAction},
+    },
+};
+
+use super::Screen;
+use anyhow::Result;
+
+pub struct TaskSelectScreen {
+    header_tabs_component: HeaderTabs,
+    task_table_component: TaskTable,
+    search_component: TextInput,
+    search_active: bool,
+}
+
+pub enum TaskSelectScreenOutcome {
+    Exit,
+    Exec(EcsTaskInfo),
+}
+
+impl TaskSelectScreen {
+    pub fn new() -> TaskSelectScreen {
+        let task_table_component = TaskTable::new();
+        let search_component = TextInput::default();
+        let mut header_tabs_component = HeaderTabs::new(Tab::ecs_flow());
+        header_tabs_component.set_selected(Tab::Tasks);
+        Self {
+            header_tabs_component,
+            task_table_component,
+            search_component,
+            search_active: false,
+        }
+    }
+
+    pub fn set_tasks(&mut self, tasks: Vec<EcsTaskInfo>) {
+        self.task_table_component.set_tasks(tasks);
+    }
+
+    fn draw(&mut self, terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
+        terminal.draw(|frame| {
+            let layout = Layout::default()
+                .direction(ratatui::layout::Direction::Vertical)
+                .margin(0)
+                .constraints([Constraint::Max(3), Constraint::Fill(1)].as_ref())
+                .split(frame.area());
+            self.header_tabs_component.view(frame, layout[0]);
+            self.task_table_component.view(frame, layout[1]);
+            if self.search_active {
+                let search_layout = Layout::default()
+                    .direction(ratatui::layout::Direction::Vertical)
+                    .constraints(vec![Constraint::Fill(1), Constraint::Max(3)])
+                    .split(layout[1]);
+                frame.render_widget(Clear, search_layout[1]);
+                self.search_component.view(frame, search_layout[1]);
+            }
+        })?;
+        Ok(())
+    }
+}
+
+impl Screen for TaskSelectScreen {
+    type Outcome = TaskSelectScreenOutcome;
+    fn run(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    ) -> Result<TaskSelectScreenOutcome> {
+        loop {
+            self.draw(terminal)?;
+            let event = event::read()?;
+            if !self.search_active {
+                let message = self.task_table_component.handle_event(event);
+                let action = self.task_table_component.update(message)?;
+                match action {
+                    Some(TaskTableOutputAction::Exit) => return Ok(TaskSelectScreenOutcome::Exit),
+                    Some(TaskTableOutputAction::ReturnTask(task)) => {
+                        return Ok(TaskSelectScreenOutcome::Exec(task));
+                    }
+                    Some(TaskTableOutputAction::Search) => {
+                        self.search_active = true;
+                    }
+                    None => {}
+                }
+            } else {
+                let message = self.search_component.handle_event(event);
+                let action = self.search_component.update(message)?;
+                match action {
+                    Some(TextInputOutputAction::Exit) => {
+                        self.search_active = false;
+                    }
+                    Some(TextInputOutputAction::Return(search)) => {
+                        self.task_table_component.apply_filter(search);
+                        self.search_active = false;
+                    }
+                    Some(TextInputOutputAction::PartialReturn(search)) => {
+                        self.task_table_component.apply_filter(search);
+                    }
+                    Some(TextInputOutputAction::ReturnWithKeyUp) => {
+                        self.task_table_component.previous();
+                        self.search_active = false;
+                    }
+                    Some(TextInputOutputAction::ReturnWithKeyDown) => {
+                        self.task_table_component.next();
+                        self.search_active = false;
+                    }
+                    None => {}
+                }
+            }
+        }
+    }
+}

--- a/src/screens/task_select_screen.rs
+++ b/src/screens/task_select_screen.rs
@@ -28,6 +28,9 @@ pub struct TaskSelectScreen {
     search_active: bool,
 }
 
+// Short-lived outcome enum built and matched immediately, so the size spread
+// between the data and unit variants does not matter (mirrors the EC2 outcome enums).
+#[allow(clippy::large_enum_variant)]
 pub enum TaskSelectScreenOutcome {
     Exit,
     Exec(EcsTaskInfo),


### PR DESCRIPTION
Adds an parallel option in addition to EC2 to connect to ECS tasks using [ECS Exec](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html)

It also adds an option in the config menu to disable one of the modes, to avoid having to select the option every time if you don't have a use case for one of the two.